### PR TITLE
Update cyg-get

### DIFF
--- a/packages/cyg-get/tools/cyg-get.ps1
+++ b/packages/cyg-get/tools/cyg-get.ps1
@@ -10,9 +10,8 @@ elseif ($package -eq '-help' -or $package -eq '/?') {
 }
 else {
   try {
-    Set-Location -Path (Get-ItemProperty HKLM:\SOFTWARE\Cygwin\setup -Name rootdir).rootdir
-    $cygwinsetup = Get-Command cygwinsetup.exe
-    $cygRoot = Split-Path -parent $cygwinsetup.Path
+    $cygRoot = (Get-ItemProperty HKLM:\SOFTWARE\Cygwin\setup -Name rootdir).rootdir
+    $cygwinsetup = Get-Command $cygRoot"\cygwinsetup.exe"
     $cygPackages = join-path $cygRoot packages
 
     Write-Host "Attempting to install `'$package`' to `'$cygPackages`'"


### PR DESCRIPTION
Update cyg-get to be able to run straight after installing cyg-get, if you don't close and reopen Powershell after installing cyg-get (spawning a new Powershell within doesn't work), cyg-get doesn't work. This will make cyg-get find the cygwinsetup.exe without restarting Powershell.
