### PR TITLE
Updated Pale Moon for use with FossHub

### DIFF
--- a/automatic/palemoon/palemoon.ketarin.xml
+++ b/automatic/palemoon/palemoon.ketarin.xml
@@ -113,7 +113,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>Textual</VariableType>
             <Regex />
-            <TextualContent>http://relmirror.palemoon.org/release/palemoon-{version}.win64.installer.exe</TextualContent>
+            <TextualContent>http://www.fosshub.com/genLink/Pale-Moon/palemoon-{version}.win64.installer.exe</TextualContent>
             <Name>url64</Name>
           </UrlVariable>
         </value>

--- a/automatic/palemoon/tools/Get-UrlFromFosshub.ps1
+++ b/automatic/palemoon/tools/Get-UrlFromFosshub.ps1
@@ -1,0 +1,23 @@
+# Get the resolved URL form a FossHub download link.
+#
+# Takes a FossHub URL in the “genLink” format and returns the generated expiring download link for the file which can
+# be used for downloading with Ketarin/Chocolatey.
+#
+# Usage: Get-UrlFromFosshub genLink_url
+# Examples:
+# Get-UrlFromFosshub http://www.fosshub.com/genLink/Light-Alloy/LA_Setup_v4.8.8.exe
+
+Function Get-UrlFromFosshub($genLinkUrl) {
+
+  $fosshubAppName = $genLinkUrl -match 'genLink/(.+?)/'
+  $fosshubAppName = $Matches[1]
+
+  $referer = "http://www.fosshub.com/${fosshubAppName}.html"
+
+  $webClient = New-Object System.Net.WebClient
+  $webClient.Headers.Add("Referer", $referer)
+
+  $generatedLink = $webClient.DownloadString($genLinkUrl)
+
+  return $generatedLink
+}

--- a/automatic/palemoon/tools/chocolateyInstall.ps1
+++ b/automatic/palemoon/tools/chocolateyInstall.ps1
@@ -4,5 +4,16 @@ $url = '{{DownloadUrl}}'
 $url64 = '{{DownloadUrlx64}}'
 $silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 $validExitCodes = @(0)
+$pwd = "$(split-path -parent $MyInvocation.MyCommand.Definition)"
+
+
+
+# Combatibility - This function has not been merged
+if (!(Get-Command Get-UrlFromFosshub -errorAction SilentlyContinue)) {
+	Import-Module "$($pwd)\Get-UrlFromFosshub.ps1"
+}
+
+$url = Get-UrlFromFosshub $url
+$url64 = Get-UrlFromFosshub $url64
 
 Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" "$url64" -validExitCodes $validExitCodes


### PR DESCRIPTION
This does require manually changing the __ketarin__ url's passed to `chocopkgup` both for `url` and `url64`

`url` `http://www.fosshub.com/genLink/Pale-Moon/palemoon-{version}.win32.installer.exe`
`url64` `http://www.fosshub.com/genLink/Pale-Moon/palemoon-{version}.win64.installer.exe`

I cannot adequately edit ketarin.xml because for some reason it does not contain the 32 bit url?
