### PR TITLE
fix cygwin mirror

### DIFF
--- a/packages/cyg-get/tools/cyg-get.ps1
+++ b/packages/cyg-get/tools/cyg-get.ps1
@@ -15,7 +15,7 @@ else {
     $cygPackages = join-path $cygRoot packages
 
     Write-Host "Attempting to install `'$package`' to `'$cygPackages`'"
-    & $cygwinsetup -q -N -R $cygRoot -l $cygPackages -s ftp://mirrors.kernel.org/sourceware/cygwin -P $package
+    & $cygwinsetup -q -N -R $cygRoot -l $cygPackages -s http://mirrors.kernel.org/sourceware/cygwin -P $package
   }
   catch {
     Write-Error "Please ensure you have cygwin installed (with chocolatey). To install please call 'cinst cygwin'. ERROR: $($_.Exception.Message)"


### PR DESCRIPTION
This package is still using the FTP mirror that has been deprecated. See the https://chocolatey.org/packages/cygwin "Release Notes" for version 1.7.33.20150102. 