### PR TITLE
added dependency: vcredist2013

### DIFF
--- a/automatic/smartftp/smartftp.nuspec
+++ b/automatic/smartftp/smartftp.nuspec
@@ -14,6 +14,9 @@
     <licenseUrl>https://www.smartftp.com/static/Products/Client/License.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <iconUrl>http://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/902e5ef38ce03246ded5756cb368ee103605d7f8/icons/smartftp.png</iconUrl>
+    <dependencies>
+      <dependency id="vcredist2013" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
the .msi no longer contains the vcredist 2013 merge module. It is now a prerequisite.