### PR TITLE
cyg-get support for multiple packages to be installed in a single cygwinsetup session

### DIFF
--- a/packages/cyg-get/tools/cyg-get.ps1
+++ b/packages/cyg-get/tools/cyg-get.ps1
@@ -6,16 +6,17 @@ if ($package -eq "" -or $package -eq $null) {
   Write-Warning 'Please specify a package or list of packages. Run -help or /? for more information.'
 }
 elseif ($package -eq '-help' -or $package -eq '/?') {
-  Write-Host "To run please specify `'cyg-get packageName`'. At the current time it doesn't appear that passing a list of packages works, but it would be done like this: `'cyg-get package1,package2,packageN`'. Note the commas and no spaces."
+  Write-Host "To run please specify `'cyg-get packageName`'. You can also specify a list of packages like this: `'cyg-get package1,package2,packageN`'. Note the commas and no spaces."
 }
 else {
   try {
     $cygRoot = (Get-ItemProperty HKLM:\SOFTWARE\Cygwin\setup -Name rootdir).rootdir
     $cygwinsetup = Get-Command $cygRoot"\cygwinsetup.exe"
-    $cygPackages = join-path $cygRoot packages
+    $cygLocalPackagesDir = join-path $cygRoot packages
+    $cygInstallPackageList = $package  -replace(" ",",")
 
-    Write-Host "Attempting to install `'$package`' to `'$cygPackages`'"
-    & $cygwinsetup -q -N -R $cygRoot -l $cygPackages -P $package
+    Write-Host "Attempting to install cygwin packages: $cygInstallPackageList"
+    & $cygwinsetup -q -N -R $cygRoot -l $cygLocalPackagesDir -P $cygInstallPackageList
   }
   catch {
     Write-Error "Please ensure you have cygwin installed (with chocolatey). To install please call 'cinst cygwin'. ERROR: $($_.Exception.Message)"

--- a/packages/cyg-get/tools/cyg-get.ps1
+++ b/packages/cyg-get/tools/cyg-get.ps1
@@ -5,7 +5,7 @@ param(
 if ($package -eq "" -or $package -eq $null) {
   Write-Warning 'Please specify a package or list of packages. Run -help or /? for more information.'
 }
-elseif ($package -eq '-help' -or $package -eq '/?') {
+elseif ($package -eq '-help' -or $package -eq '--help' -or $package -eq '-h' -or $package -eq '/?') {
   Write-Host "To run please specify `'cyg-get packageName`'. You can also specify a list of packages like this: `'cyg-get package1,package2,packageN`'. Note the commas and no spaces."
 }
 else {


### PR DESCRIPTION
The help text in cyg-get seemed to imply that support for installing multiple packages was not available.

This is however not true, it has been supported in cygwin setup.exe from the start, however the powershell script was parsing the arguments and removing the commas that separate the packages.

It works correctly with this patch.

It would be nice if  "choco install package1 package2 -source cygwin" was able to make use of this instead of launching a separate cygwinsetup every time... which is very slow and requires redownloading the package indexes every time.