### PR TITLE
Created hostsman autopackage

### DIFF
--- a/automatic/hostsman/hostsman.ketarin.xml
+++ b/automatic/hostsman/hostsman.ketarin.xml
@@ -1,0 +1,65 @@
+﻿<?xml version='1.0' encoding='utf-8'?>
+<Jobs>
+  <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="a719dae1-73b0-4dc4-8e69-8b9ae6bda771">
+    <WebsiteUrl />
+    <UserAgent />
+    <UserNotes />
+    <LastFileSize>12915824</LastFileSize>
+    <LastFileDate>2015-10-19T05:58:29.316572</LastFileDate>
+    <IgnoreFileInformation>false</IgnoreFileInformation>
+    <DownloadBeta>Default</DownloadBeta>
+    <DownloadDate xsi:nil="true" />
+    <CheckForUpdatesOnly>false</CheckForUpdatesOnly>
+    <VariableChangeIndicator />
+    <CanBeShared>true</CanBeShared>
+    <ShareApplication>false</ShareApplication>
+    <ExclusiveDownload>false</ExclusiveDownload>
+    <HttpReferer />
+    <SetupInstructions />
+    <Variables>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>(?&lt;=Version:.+)([0-9-.]+)</Regex>
+            <Url>http://www.abelhadigital.com/hostsman</Url>
+            <TextualContent>{realVersion:replace:-:.}</TextualContent>
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>url</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>http://hostsman2.it-mate.co.uk/HostsMan_{version}_installer.zip</TextualContent>
+            <Name>url</Name>
+          </UrlVariable>
+        </value>
+      </item>
+    </Variables>
+    <ExecuteCommand />
+    <ExecutePreCommand />
+    <ExecuteCommandType>Batch</ExecuteCommandType>
+    <ExecutePreCommandType>Batch</ExecutePreCommandType>
+    <Category />
+    <SourceType>FixedUrl</SourceType>
+    <PreviousLocation>C:\Chocolatey\_work\</PreviousLocation>
+    <DeletePreviousFile>true</DeletePreviousFile>
+    <Enabled>true</Enabled>
+    <FileHippoId />
+    <LastUpdated>2015-10-19T05:58:29.316572</LastUpdated>
+    <TargetPath>C:\Chocolatey\_work\</TargetPath>
+    <FixedDownloadUrl>{url}</FixedDownloadUrl>
+    <Name>HostsMan</Name>
+  </ApplicationJob>
+</Jobs>

--- a/automatic/hostsman/hostsman.nuspec
+++ b/automatic/hostsman/hostsman.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>hostsman</id>
+        <version>{{PackageVersion}}</version>
+        <title>HostsMan</title>
+        <authors>abelhadigital.com</authors>
+        <owners>Redsandro</owners>
+        <licenseUrl>http://hostsman.it-mate.co.uk/licenses/hostsman_4.txt</licenseUrl>
+        <projectUrl>http://www.abelhadigital.com/hostsman</projectUrl>
+        <iconUrl>https://i.imgur.com/gnIXWoE.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__HostsMan__ is a freeware application that lets you manage your Hosts file with ease. No Spyware! No Adware! No Viruses! 100% Freeware! Clean and simple.</description>
+        <summary>HostsMan is a freeware application that lets you manage your Hosts file with ease.</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>Security Hosts hostsfile</tags>
+    </metadata>
+</package>

--- a/automatic/hostsman/tools/chocolateyInstall.ps1
+++ b/automatic/hostsman/tools/chocolateyInstall.ps1
@@ -1,0 +1,24 @@
+$name		= 'HostsMan'
+$zipName	= "$name.zip"
+$installer	= "HostsMan_Setup.exe"
+$silentArgs	= "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"
+$url		= '{{DownloadUrl}}'
+$pwd		= "$(split-path -parent $MyInvocation.MyCommand.Definition)"
+
+
+
+$tempDir = Join-Path $env:TEMP $name
+	if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
+
+$filePath = Join-Path $tempDir $zipName
+
+# Download zip
+Get-ChocolateyWebFile "$name" "$filePath" "$url"
+
+# Extract zip
+Get-ChocolateyUnzip "$filePath" "$tempDir"
+
+$exeName = Join-Path $tempDir "$installer"
+
+# Execute installer
+Install-ChocolateyPackage "$name" "EXE" "$silentArgs" "$exeName"


### PR DESCRIPTION
I get the following when I try to test:

```
The packages folder 'C:\code\mine\chocolateyautomaticpackages\name' does not exist. Perhaps you meant to specify the name as something else or you want to override the packages folder path setting of 'C:\code\mine\chocolateyautomaticpackages'. See chocopkgup.exe /help for details.
```

Could someone give a hint?