### PR TITLE
smartftp: fix incorrect version string.

### DIFF
--- a/automatic/smartftp/smartftp.nuspec
+++ b/automatic/smartftp/smartftp.nuspec
@@ -16,7 +16,7 @@
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/97d1e867fd5feaee1b89b24ffe6d40c22c819dc3/icons/smartftp.svg</iconUrl>
     <bugTrackerUrl>https://www.smartftp.com/forums/index.php?/forum/14-support/</bugTrackerUrl>
     <dependencies>
-      <dependency id="vcredist2015" version="(14.0.23506.0,)"/>
+      <dependency id="vcredist2015" version="[14.0.23506.0,]"/>
     </dependencies>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
   </metadata>


### PR DESCRIPTION
It should have been [min,] instead of (min,)