### PR TITLE
Add Flash Player PPAPI plugin for Opera and Chromium browsers

### DIFF
--- a/automatic/flashplayerppapi/flashplayerppapi.ketarin.xml
+++ b/automatic/flashplayerppapi/flashplayerppapi.ketarin.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <Jobs>
+   <ApplicationJob xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   Guid="38dd3a9e-db17-4308-8d93-ce4d30048de8">
+      <SourceTemplate><![CDATA[<?xml version="1.0" encoding="utf-8"?>
+<Jobs>
+  <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="0fb30714-8ed0-4611-8f1b-cb8fec9dae91">
+    <WebsiteUrl />	
+    <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
+    <UserNotes />
+    <LastFileSize>384846</LastFileSize>
+    <LastFileDate>2012-05-23T02:09:37.7748325</LastFileDate>
+    <IgnoreFileInformation>false</IgnoreFileInformation>
+    <DownloadBeta>Default</DownloadBeta>
+    <DownloadDate xsi:nil="true" />
+    <CheckForUpdatesOnly>false</CheckForUpdatesOnly>
+    <VariableChangeIndicator />
+    <CanBeShared>true</CanBeShared>
+    <ShareApplication>false</ShareApplication>
+    <ExclusiveDownload>false</ExclusiveDownload>
+    <HttpReferer />
+    <SetupInstructions />
+    <Variables>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>StartEnd</VariableType>
+            <Regex />
+            <Url><placeholder name="Url with version information" value="https://get.adobe.com/flashplayer/webservices/adm/?cname=&amp;bname=flashplayerpp" /></Url>
+            <StartText>&lt;TABLE cellspacing ="1" cellpadding ="6" border = "0"&gt;
+  &lt;TR&gt;
+    &lt;TH class="Title" align="center" width=90&gt;7-Zip </StartText>
+            <EndText>&lt;BR&gt;</EndText>
+            <TextualContent />
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>url64</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>""</TextualContent>
+            <Name>url64</Name>
+          </UrlVariable>
+        </value>
+      </item>
+    </Variables>
+    <ExecuteCommand />
+    <ExecutePreCommand />
+    <ExecuteCommandType>Batch</ExecuteCommandType>
+    <ExecutePreCommandType>Batch</ExecutePreCommandType>
+    <Category />
+    <SourceType>FixedUrl</SourceType>
+    <PreviousLocation />
+    <DeletePreviousFile>true</DeletePreviousFile>
+    <Enabled>true</Enabled>
+    <FileHippoId />
+    <LastUpdated>2012-05-23T02:09:37.7748325</LastUpdated>
+    <TargetPath>C:\Chocolatey\_work\</TargetPath>
+    <FixedDownloadUrl><placeholder name="Download Url - Optional" value="https://fpdownload.adobe.com/pub/flashplayer/pdc/{version}/install_flash_player_ppapi.exe" /></FixedDownloadUrl>
+    <Name><placeholder name="Name" value="flashplayerppapi" /></Name>
+  </ApplicationJob>
+</Jobs>]]></SourceTemplate>
+      <WebsiteUrl/>
+      <UserAgent/>
+      <UserNotes/>
+      <LastFileSize>19604160</LastFileSize>
+      <LastFileDate>2016-01-13T17:11:20+08:00</LastFileDate>
+      <IgnoreFileInformation>false</IgnoreFileInformation>
+      <DownloadBeta>Default</DownloadBeta>
+      <DownloadDate xsi:nil="true"/>
+      <CheckForUpdatesOnly>false</CheckForUpdatesOnly>
+      <VariableChangeIndicator/>
+      <CanBeShared>true</CanBeShared>
+      <ShareApplication>false</ShareApplication>
+      <ExclusiveDownload>false</ExclusiveDownload>
+      <HttpReferer/>
+      <SetupInstructions/>
+      <Variables>
+         <item>
+            <key>
+               <string>version</string>
+            </key>
+            <value>
+               <UrlVariable>
+                  <RegexRightToLeft>false</RegexRightToLeft>
+                  <VariableType>RegularExpression</VariableType>
+                  <Regex>(?&gt;&lt;version&gt;)([0-9.]*)(?&gt;&lt;\/version)</Regex>
+                  <Url>https://get.adobe.com/flashplayer/webservices/adm/?cname=&amp;bname=flashplayerpp</Url>
+                  <StartText>&lt;TABLE cellspacing ="1" cellpadding ="6" border = "0"&gt;
+  &lt;TR&gt;
+    &lt;TH class="Title" align="center" width=90&gt;7-Zip </StartText>
+                  <EndText>&lt;BR&gt;</EndText>
+                  <TextualContent/>
+                  <Name>version</Name>
+               </UrlVariable>
+            </value>
+         </item>
+         <item>
+            <key>
+               <string>url64</string>
+            </key>
+            <value>
+               <UrlVariable>
+                  <RegexRightToLeft>false</RegexRightToLeft>
+                  <VariableType>Textual</VariableType>
+                  <Regex/>
+                  <TextualContent>""</TextualContent>
+                  <Name>url64</Name>
+               </UrlVariable>
+            </value>
+         </item>
+      </Variables>
+      <ExecuteCommand/>
+      <ExecutePreCommand/>
+      <ExecuteCommandType>Batch</ExecuteCommandType>
+      <ExecutePreCommandType>Batch</ExecutePreCommandType>
+      <Category/>
+      <SourceType>FixedUrl</SourceType>
+      <PreviousLocation/>
+      <DeletePreviousFile>true</DeletePreviousFile>
+      <Enabled>true</Enabled>
+      <FileHippoId/>
+      <LastUpdated>2016-01-20T15:53:24.8330813+08:00</LastUpdated>
+      <TargetPath>C:\Chocolatey\_work\</TargetPath>
+      <FixedDownloadUrl>https://fpdownload.adobe.com/pub/flashplayer/pdc/{version}/install_flash_player_ppapi.exe</FixedDownloadUrl>
+      <Name>flashplayerppapi</Name>
+   </ApplicationJob>
+</Jobs>

--- a/automatic/flashplayerppapi/flashplayerppapi.nuspec
+++ b/automatic/flashplayerppapi/flashplayerppapi.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>flashplayerppapi</id>
+    <title>Flash Player PPAPI</title>
+    <version>20.0.0.286</version>
+    <authors>Adobe Systems Incorporated</authors>
+    <owners>Adobe Systems Incorporated</owners>
+    <summary>Adobe Flash Player PPAPI Plugin for Opera and Chromium based browsers</summary>
+    <description>The Adobe Flash Player is freeware software for viewing multimedia, executing Rich Internet Applications, and streaming video and audio, content created on the Adobe Flash platform.</description>
+    <projectUrl>https://www.adobe.com/software/flash/about/</projectUrl>
+    <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/e4a49519947c3cff55c17a0b08266c56b0613e64/icons/flashplayer.png</iconUrl>
+    <tags>adobe flash player ppapi plugin admin</tags>
+    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
+    <licenseUrl>https://www.adobe.com/products/clients/all_dist_agreement.html</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/automatic/flashplayerppapi/flashplayerppapi.nuspec
+++ b/automatic/flashplayerppapi/flashplayerppapi.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>flashplayerppapi</id>
+    <id>{{PackageName}}</id>
     <title>Flash Player PPAPI</title>
-    <version>20.0.0.286</version>
+    <version>{{PackageVersion}}</version>
     <authors>Adobe Systems Incorporated</authors>
     <owners>Adobe Systems Incorporated</owners>
     <summary>Adobe Flash Player PPAPI Plugin for Opera and Chromium based browsers</summary>

--- a/automatic/flashplayerppapi/tools/ChocolateyInstall.ps1
+++ b/automatic/flashplayerppapi/tools/ChocolateyInstall.ps1
@@ -1,7 +1,7 @@
-﻿$packageName = 'flashpluginppapi'
-$version = '20.0.0.286'
+﻿$packageName = '{{PackageName}}'
+$version = '{{PackageVersion}}'
 $installerType = 'exe'
-$url = 'https://fpdownload.adobe.com/pub/flashplayer/pdc/20.0.0.286/install_flash_player_ppapi.exe'
+$url = '{{DownloadUrl}}'
 $silentArgs = '-install'
 $validExitCodes = @(0)
 

--- a/automatic/flashplayerppapi/tools/ChocolateyInstall.ps1
+++ b/automatic/flashplayerppapi/tools/ChocolateyInstall.ps1
@@ -1,0 +1,9 @@
+﻿$packageName = 'flashpluginppapi'
+$version = '20.0.0.286'
+$installerType = 'exe'
+$url = 'https://fpdownload.adobe.com/pub/flashplayer/pdc/20.0.0.286/install_flash_player_ppapi.exe'
+$silentArgs = '-install'
+$validExitCodes = @(0)
+
+#installer automatically overrides existing PPAPI installation
+Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url"  -validExitCodes $validExitCodes

--- a/automatic/flashplayerppapi/tools/ChocolateyUninstall.ps1
+++ b/automatic/flashplayerppapi/tools/ChocolateyUninstall.ps1
@@ -1,4 +1,4 @@
-﻿$packageName = 'flashplayerppapi'
+﻿$packageName = '{{PackageName}}'
 $programName = 'Adobe Flash Player PPAPI'
 $fileType = 'EXE'
 $silentArgs = '-uninstall pepperplugin'

--- a/automatic/flashplayerppapi/tools/ChocolateyUninstall.ps1
+++ b/automatic/flashplayerppapi/tools/ChocolateyUninstall.ps1
@@ -1,0 +1,13 @@
+﻿$registryPaths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstallString = (Get-ChildItem -Path $registryPaths |
+    Get-ItemProperty |
+    Where-Object {$_.DisplayName -match 'Mp3tag' } |
+    Select-Object -Property DisplayName, UninstallString).uninstallString -replace "maintain","uninstall"
+
+if ($uninstString) {
+    Uninstall-ChocolateyPackage 'flashplayerppapi' 'exe' '' $uninstString
+}

--- a/automatic/flashplayerppapi/tools/ChocolateyUninstall.ps1
+++ b/automatic/flashplayerppapi/tools/ChocolateyUninstall.ps1
@@ -1,13 +1,16 @@
-﻿$registryPaths = @(
-  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
-  'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
-)
+﻿$packageName = 'flashplayerppapi'
+$programName = 'Adobe Flash Player PPAPI'
+$fileType = 'EXE'
+$silentArgs = '-uninstall pepperplugin'
 
-$uninstallString = (Get-ChildItem -Path $registryPaths |
-    Get-ItemProperty |
-    Where-Object {$_.DisplayName -match 'Mp3tag' } |
-    Select-Object -Property DisplayName, UninstallString).uninstallString -replace "maintain","uninstall"
+$key32 = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\'
+$key64 = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\'
+$key = @{64=$key64;32=$key32}[(Get-ProcessorBits)]
 
-if ($uninstString) {
-    Uninstall-ChocolateyPackage 'flashplayerppapi' 'exe' '' $uninstString
+$uninstaller = Get-ChildItem $key | %{ Get-ItemProperty $_.PSPath } | ?{ $_.PSChildName -match $programName }
+
+$uninstallString = $uninstaller.uninstallString -replace " -maintain pepperplugin",""
+
+if ($uninstallString) {
+    Uninstall-ChocolateyPackage $packageName $fileType $silentArgs $uninstallString
 }


### PR DESCRIPTION
- uses a different URL and source for $version, may work for the NPAPI and ActiveX packages
- Adobe did not release MSI installer for the PPAPI version (see https://forums.adobe.com/message/8108499#8108499), but the EXE installer supports silent setup. 
- reuses existing Flash icon
- tested installation and uninstallation on Win7 x64 with Chromium 49.0.2598.0 x64

My first PR to this project, please review