### PR TITLE
(cyg-get) Fix the path of cygwinsetup.exe

### DIFF
--- a/packages/cyg-get/tools/cyg-get.ps1
+++ b/packages/cyg-get/tools/cyg-get.ps1
@@ -57,8 +57,9 @@ if ($help -or $packageNames -join '|' -eq '/?') {
       }
     }
 
-    $cygwinsetup = "$cygRoot\cygwinsetup.exe"
-    $cygLocalPackagesDir = join-path $cygRoot packages
+    $cygwinsetupDir = "${Env:ChocolateyInstall}\lib\Cygwin\tools\cygwin"
+    $cygwinsetup = "$cygwinsetupDir\cygwinsetup.exe"
+    $cygLocalPackagesDir = join-path $cygwinsetupDir packages
     $cygInstallPackageList = $packageNames -join ','
 
     $cygArgs = "--root $cygRoot --local-package-dir $cygLocalPackagesDir"


### PR DESCRIPTION
`cygwinsetup.exe` is sure to be found in `${Env:ChocolateyInstall}\lib\Cygwin\tools\cygwin`, as cyg-get depends on Cygwin.

However, it's not guaranteed to be found in the installation rootdir of Cygwin under the following circumstances:
1. Cygwin is installed manually to another path, and then installed by chocolatey;
2. When rootdir of Cygwin can be customized when installing via Chocolatey in the future.

This PR is intended to fix installation described in the following image:

![cygwinnotfound](https://cloud.githubusercontent.com/assets/2920525/12723379/21470b74-c944-11e5-8541-5c8a542355d3.png)

After patch:

![afterpatch](https://cloud.githubusercontent.com/assets/2920525/12723460/8bd3cf72-c944-11e5-9a30-238b0d45040b.png)
