### PR TITLE
KeePassX autopackage

### DIFF
--- a/automatic/keepassx/keepassx.ketarin.xml
+++ b/automatic/keepassx/keepassx.ketarin.xml
@@ -1,0 +1,131 @@
+﻿<?xml version='1.0' encoding='utf-8'?>
+<Jobs>
+  <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="48990104-8c8d-401f-a9c2-60653fc81c65">
+    <SourceTemplate><![CDATA[<Jobs>
+  <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="0fb30714-8ed0-4611-8f1b-cb8fec9dae91">
+    <WebsiteUrl />
+    <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
+    <UserNotes />
+    <LastFileSize>384846</LastFileSize>
+    <LastFileDate>2012-05-23T02:09:37.7748325</LastFileDate>
+    <IgnoreFileInformation>false</IgnoreFileInformation>
+    <DownloadBeta>Default</DownloadBeta>
+    <DownloadDate xsi:nil="true" />
+    <CheckForUpdatesOnly>false</CheckForUpdatesOnly>
+    <VariableChangeIndicator />
+    <CanBeShared>true</CanBeShared>
+    <ShareApplication>false</ShareApplication>
+    <ExclusiveDownload>false</ExclusiveDownload>
+    <HttpReferer />
+    <SetupInstructions />
+    <Variables>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>StartEnd</VariableType>
+            <Regex />
+            <Url><placeholder name="Url with version information" value="http://sourceforge.net/projects/calibre/files/" /></Url>
+            <StartText>&lt;TABLE cellspacing ="1" cellpadding ="6" border = "0"&gt;
+  &lt;TR&gt;
+    &lt;TH class="Title" align="center" width=90&gt;7-Zip </StartText>
+            <EndText>&lt;BR&gt;</EndText>
+            <TextualContent />
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>url64</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>""</TextualContent>
+            <Name>url64</Name>
+          </UrlVariable>
+        </value>
+      </item>
+    </Variables>
+    <ExecuteCommand />
+    <ExecutePreCommand />
+    <ExecuteCommandType>Batch</ExecuteCommandType>
+    <ExecutePreCommandType>Batch</ExecutePreCommandType>
+    <Category />
+    <SourceType>FixedUrl</SourceType>
+    <DeletePreviousFile>true</DeletePreviousFile>
+    <Enabled>true</Enabled>
+    <FileHippoId />
+    <LastUpdated>2012-05-23T02:09:37.7748325</LastUpdated>
+    <TargetPath>C:\Chocolatey\_work\</TargetPath>
+    <FixedDownloadUrl><placeholder name="Download Url - Optional" value="http://freefr.dl.sourceforge.net/project/calibre/{version}/calibre-{version}.msi" /></FixedDownloadUrl>
+    <Name><placeholder name="Name" value="calibre" /></Name>
+  </ApplicationJob>
+</Jobs>]]></SourceTemplate>
+    <WebsiteUrl />
+    <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
+    <UserNotes />
+    <LastFileSize>35</LastFileSize>
+    <LastFileDate>1998-05-16T20:00:00-07:00</LastFileDate>
+    <IgnoreFileInformation>true</IgnoreFileInformation>
+    <DownloadBeta>Default</DownloadBeta>
+    <DownloadDate xsi:nil="true" />
+    <CheckForUpdatesOnly>false</CheckForUpdatesOnly>
+    <VariableChangeIndicator>version</VariableChangeIndicator>
+    <CanBeShared>true</CanBeShared>
+    <ShareApplication>false</ShareApplication>
+    <ExclusiveDownload>false</ExclusiveDownload>
+    <HttpReferer />
+    <SetupInstructions />
+    <Variables>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>releases/([0-9\.]{3,9})/</Regex>
+            <Url>https://www.keepassx.org/downloads/</Url>
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>url</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>StartEnd</VariableType>
+            <Regex />
+            <Url>https://www.keepassx.org/releases/{version}/KeePassX-{version}.zip</Url>
+            <Name>url</Name>
+          </UrlVariable>
+        </value>
+      </item>
+    </Variables>
+    <ExecuteCommand />
+    <ExecutePreCommand />
+    <ExecuteCommandType>Batch</ExecuteCommandType>
+    <ExecutePreCommandType>Batch</ExecutePreCommandType>
+    <Category />
+    <SourceType>FixedUrl</SourceType>
+    <PreviousLocation>C:\Chocolatey\_work\__utm.gif</PreviousLocation>
+    <DeletePreviousFile>true</DeletePreviousFile>
+    <Enabled>true</Enabled>
+    <FileHippoId />
+    <LastUpdated>2016-06-08T02:25:11.6204462-07:00</LastUpdated>
+    <TargetPath>C:\Chocolatey\_work\</TargetPath>
+    <FixedDownloadUrl>{url}</FixedDownloadUrl>
+    <Name>keepassx</Name>
+  </ApplicationJob>
+</Jobs>

--- a/automatic/keepassx/keepassx.ketarin.xml
+++ b/automatic/keepassx/keepassx.ketarin.xml
@@ -71,8 +71,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>35</LastFileSize>
-    <LastFileDate>1998-05-16T20:00:00-07:00</LastFileDate>
+		<LastFileSize>15</LastFileSize>
+    <LastFileDate>2000-01-00T00:00:00-01:00</LastFileDate>
     <IgnoreFileInformation>true</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -105,9 +105,10 @@
         <value>
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
-            <VariableType>StartEnd</VariableType>
+            <VariableType>Textual</VariableType>
             <Regex />
-            <Url>https://www.keepassx.org/releases/{version}/KeePassX-{version}.zip</Url>
+            <Url />
+            <TextualContent>https://www.keepassx.org/releases/{version}/KeePassX-{version}.zip</TextualContent>
             <Name>url</Name>
           </UrlVariable>
         </value>
@@ -119,11 +120,11 @@
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
     <SourceType>FixedUrl</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\__utm.gif</PreviousLocation>
+    <PreviousLocation>C:\Chocolatey\_work\KeePassX-0.4.3.zip</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2016-06-08T02:25:11.6204462-07:00</LastUpdated>
+    <LastUpdated>2000-01-00T00:00:00.0000000-01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
     <FixedDownloadUrl>{url}</FixedDownloadUrl>
     <Name>keepassx</Name>

--- a/automatic/keepassx/keepassx.nuspec
+++ b/automatic/keepassx/keepassx.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+	<metadata>
+		<id>{{PackageName}}</id>
+		<title>KeePassX Password Manager</title>
+		<version>{{PackageVersion}}</version>
+		<authors>KeePassX Team</authors>
+		<owners>chocolatey</owners>
+		<summary>KeePassX is an application for people with extremly high demands on secure personal data management. It has a light interface, is cross platform and published under the terms of the GNU General Public License.</summary>
+		<description>
+**KeePassX** saves many different information e.g. user names, passwords, urls, attachments and comments in one single database. For a better management user-defined titles and icons can be specified for each single entry. Furthermore the entries are sorted in groups, which are customizable as well.
+
+The databases are encrypted using the best and most secure encryption algorithms currently known (AES and Twofish).
+
+Originally KeePassX was called KeePass/L for Linux since it was a port of Windows password manager Keepass Password Safe. After KeePass/L became a cross platform application the name was not appropriate anymore and therefore, on 22 March 2006 it has been changed.
+		</description>
+		<projectUrl>http://www.keepassx.org/</projectUrl>
+		<tags>multiplatform password safe</tags>
+		<copyright></copyright>
+		<licenseUrl>http://www.gnu.org/licenses/gpl.html</licenseUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<iconUrl>https://i.imgur.com/AOOQAAp.png</iconUrl>
+		<dependencies></dependencies>
+		<releaseNotes></releaseNotes>
+	</metadata>
+	<files>
+		<file src="tools\**" target="tools" />
+		<!--<file src="content\**" target="content" />-->
+	</files>
+</package>

--- a/automatic/keepassx/tools/chocolateyInstall.ps1
+++ b/automatic/keepassx/tools/chocolateyInstall.ps1
@@ -1,0 +1,13 @@
+$pwd			= "$(split-path -parent $MyInvocation.MyCommand.Definition)"
+
+Install-ChocolateyZipPackage "KeePassX" "{{DownloadUrl}}" "$pwd"
+
+# Add to start menu
+
+$appData = [environment]::GetFolderPath([environment+specialfolder]::ApplicationData)
+$destPath = Join-Path "$appData" "Microsoft\Windows\Start Menu\Programs\"
+$destLink = Join-Path "$destPath" "KeePassX.lnk"
+$shell = New-Object -comObject WScript.Shell
+$shortcut = $shell.CreateShortcut($destLink)
+$shortcut.TargetPath = Join-Path "$pwd" "KeePassX\KeePassX.exe"
+$shortcut.Save()


### PR DESCRIPTION
@gep13 This is also an old static package turned autopackage because updates were requested.
This one should be straightforward because the download is direct (no mirrors) and the installer is just a .zip.