### PR TITLE
Update chocolateyInstall.ps1

### DIFF
--- a/automatic/WinPcap/tools/chocolateyInstall.ps1
+++ b/automatic/WinPcap/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿try {
   $packageName = '{{PackageName}}'
   $url = '{{DownloadUrl}}'
-  $filePath = "$env:TEMP\chocolatey\winpcap"
+  $filePath = "$env:TEMP\winpcap"
   $fileFullPath = "$filePath\winpcapInstall.exe"
 
   if (!(Test-Path $filePath)) {


### PR DESCRIPTION
The installer download directory is not correct. When attempting to install, choco is looking for winpcapInstall.exe in %USERPROFILE%\AppData\Local\Temp\chocolatey\winpcap and it is currently being copied to %USERPROFILE%\AppData\Local\Temp\chocolatey\chocolatey\winpcap