### PR TITLE
Added Python2 and Python3 Scripts dir to PATH using installer option (#111)

### DIFF
--- a/automatic/python2-x86_32/tools/chocolateyInstall.ps1
+++ b/automatic/python2-x86_32/tools/chocolateyInstall.ps1
@@ -5,7 +5,7 @@ $url = '{{DownloadUrl}}'
 $url64 = '{{DownloadUrlx64}}'
 $version = '{{PackageVersion}}'
 $fileType = 'msi'
-$partialInstallArgs = '/qn /norestart ALLUSERS=1 TARGETDIR='
+$partialInstallArgs = '/qn /norestart ALLUSERS=1 ADDLOCAL=ALL TARGETDIR='
 
 
 

--- a/automatic/python2/tools/chocolateyInstall.ps1
+++ b/automatic/python2/tools/chocolateyInstall.ps1
@@ -5,7 +5,7 @@ $url = '{{DownloadUrl}}'
 $url64 = '{{DownloadUrlx64}}'
 $version = '{{PackageVersion}}'
 $fileType = 'msi'
-$partialInstallArgs = '/qn /norestart ALLUSERS=1 TARGETDIR='
+$partialInstallArgs = '/qn /norestart ALLUSERS=1 ADDLOCAL=ALL TARGETDIR='
 
 
 

--- a/automatic/python3-x86_32/tools/chocolateyInstall.ps1
+++ b/automatic/python3-x86_32/tools/chocolateyInstall.ps1
@@ -5,7 +5,7 @@ $url = '{{DownloadUrl}}'
 $url64 = '{{DownloadUrlx64}}'
 $version = '{{PackageVersion}}'
 $fileType = 'exe'
-$partialInstallArgs = '/quiet InstallAllUsers=1'
+$partialInstallArgs = '/quiet InstallAllUsers=1 PrependPath=1'
 
 $installPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 

--- a/automatic/python3/tools/chocolateyInstall.ps1
+++ b/automatic/python3/tools/chocolateyInstall.ps1
@@ -5,7 +5,7 @@ $url = '{{DownloadUrl}}'
 $url64 = '{{DownloadUrlx64}}'
 $version = '{{PackageVersion}}'
 $fileType = 'exe'
-$partialInstallArgs = '/quiet InstallAllUsers=1'
+$partialInstallArgs = '/quiet InstallAllUsers=1 PrependPath=1'
 
 $installPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 


### PR DESCRIPTION
This allows pip installed programs that provide scripts to be accessible from the `cmd.exe`. This is how this works on Linux.

Example without this option:
```
pip3 install git+https://github.com/GoSecure/malboxes.git@pip-packaging#egg=malboxes
C:\...> malboxes -V
'malboxes' is not recognized as an internal or external command,
operable program or batch file.
```

Example with this option:
```
pip3 install git+https://github.com/GoSecure/malboxes.git@pip-packaging#egg=malboxes
C:\...> malboxes -V
malboxes-script.py 0.2.0dev
```