### PR TITLE
Update chocolateyInstall.ps1

### DIFF
--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $checksumType = 'md5'
   if (Test-Path $Chromium) {
     $silentArgs = ''
   } else {
-    $silentArgs = '--system-level --do-not-launch-chrome'
+    $silentArgs = '--system-level'
   }
   
     Install-ChocolateyPackage $packageName $fileType $silentArgs $url $validExitCodes $checksum $checksumType

--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
   packageName   = '{{PackageName}}'
   fileType      = 'exe'
   url           = '{{DownloadUrl}}'
-  url64bit      = '{{DownloadUrlx64'
+  url64bit      = '{{DownloadUrlx64}}'
   silentArgs    = $silentArgs
   validExitCodes= @(0)
   softwareName  = 'Chromium'
@@ -23,4 +23,4 @@ $version = '{{PackageVersion}}'
     $silentArgs = '--system-level'
   }
 
-    Install-ChocolateyPackage $packageArgs
+    Install-ChocolateyPackage @packageArgs

--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -5,7 +5,6 @@ $systemIs64bit = Get-ProcessorBits
 $url = @{$true = "{{DownloadUrlx64}}"; $false = "{{DownloadUrl}}"}[$systemIs64bit -eq 64]
 $checksum = @{$true = "{{Checksumx64}}"; $false = "{{Checksum}}"}[$systemIs64bit -eq 64]
 $checksumType = 'md5'
-$validExitCodes = @(0)
 
 	$chromium_string = "\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Chromium"
 	$hive = "hkcu"

--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -1,10 +1,17 @@
-$packageName = '{{PackageName}}'
-$fileType = 'exe'
+  $packageArgs = @{
+  packageName   = '{{PackageName}}'
+  fileType      = 'exe'
+  url           = '{{DownloadUrl}}'
+  url64bit      = '{{DownloadUrlx64'
+  silentArgs    = $silentArgs
+  validExitCodes= @(0)
+  softwareName  = 'Chromium'
+  checksum      = '{{Checksum}}'
+  checksumType  = 'md5'
+  checksum64    = '{{Checksumx64}}'
+  checksumType64= 'md5'
+}
 $version = '{{PackageVersion}}'
-$systemIs64bit = Get-ProcessorBits
-$url = @{$true = "{{DownloadUrlx64}}"; $false = "{{DownloadUrl}}"}[$systemIs64bit -eq 64]
-$checksum = @{$true = "{{Checksumx64}}"; $false = "{{Checksum}}"}[$systemIs64bit -eq 64]
-$checksumType = 'md5'
 
 	$chromium_string = "\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Chromium"
 	$hive = "hkcu"
@@ -15,5 +22,5 @@ $checksumType = 'md5'
   } else {
     $silentArgs = '--system-level'
   }
-  
-    Install-ChocolateyPackage $packageName $fileType $silentArgs $url $checksum $checksumType
+
+    Install-ChocolateyPackage $packageArgs

--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -16,4 +16,4 @@ $checksumType = 'md5'
     $silentArgs = '--system-level'
   }
   
-    Install-ChocolateyPackage $packageName $fileType $silentArgs $url $validExitCodes $checksum $checksumType
+    Install-ChocolateyPackage $packageName $fileType $silentArgs $url $checksum $checksumType


### PR DESCRIPTION
By having an valid exit code line. Chocolatey seems to think it needs a 'url64bit' expression. It is the only real change made to the install besides the checksums.

@gep13 this seems to be a interesting bug in chocolatey.