### PR TITLE
Update chocolateyInstall.ps1

### DIFF
--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -15,12 +15,12 @@ $version = '{{PackageVersion}}'
 
 	$chromium_string = "\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Chromium"
 	$hive = "hkcu"
-	$Chromium = $hive + ":\" + $chromium_string
+	$Chromium = $hive + ":" + $chromium_string
   
   if (Test-Path $Chromium) {
     $silentArgs = ''
   } else {
-    $silentArgs = '--system-level'
+    $silentArgs = '--system-level --do-not-launch-chrome'
   }
 
     Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
I noticed a glitch that even power shell didn't catch as being wrong. The  ":\" should only be ":" or the $chromium_string shouldn't start with a '\'
I also added the extra Argument of '--do-not-launch-chrome'. This was removed with all the confusion about the passing of variables to chocolatey.
@gep13 Tested and works