### PR TITLE
Update chocolateyInstall.ps1

### DIFF
--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -1,4 +1,17 @@
-  $packageArgs = @{
+
+  $version = '{{PackageVersion}}'
+
+	$chromium_string = "\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Chromium"
+	$hive = "hkcu"
+	$Chromium = $hive + ":" + $chromium_string
+  
+  if (Test-Path $Chromium) {
+    $silentArgs = ''
+  } else {
+    $silentArgs = '--system-level --do-not-launch-chrome'
+  }
+  
+    $packageArgs = @{
   packageName   = '{{PackageName}}'
   fileType      = 'exe'
   url           = '{{DownloadUrl}}'
@@ -11,16 +24,5 @@
   checksum64    = '{{Checksumx64}}'
   checksumType64= 'md5'
 }
-$version = '{{PackageVersion}}'
-
-	$chromium_string = "\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Chromium"
-	$hive = "hkcu"
-	$Chromium = $hive + ":" + $chromium_string
-  
-  if (Test-Path $Chromium) {
-    $silentArgs = ''
-  } else {
-    $silentArgs = '--system-level --do-not-launch-chrome'
-  }
 
     Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Power Shell needs to read the $silentArgs value before it reads it from the $packageArgs

@gep13 I haven't found a solution other than to change the order. This should make the package follow the install that is listed on the website now :+1: 