### PR TITLE
qBittorrent: ensure checksum gets captured

### DIFF
--- a/ketarin/qbittorrent.ketarin.xml
+++ b/ketarin/qbittorrent.ketarin.xml
@@ -139,7 +139,7 @@
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>(?&lt;=SHA-1\sChecksum:\s)\w+</Regex>
+            <Regex>(?&lt;=SHA-1\sChecksum:\s)(\w+)</Regex>
             <Url>http://www.qbittorrent.org/download.php</Url>
             <Name>checksum</Name>
           </UrlVariable>


### PR DESCRIPTION
Without the parens around `\w+` in the regex, the checksum value doesn't actually get captured for the variable. This fix should correct generation of the qBittorrent package.

Fixes #307 