### PR TITLE
FossHub genLink URLs don't work and can be easily fixed without touching affected packages.

### DIFF
--- a/extensions/chocolatey-fosshub.extension/extensions/Get-UrlFromFosshub.psm1
+++ b/extensions/chocolatey-fosshub.extension/extensions/Get-UrlFromFosshub.psm1
@@ -3,14 +3,14 @@
 # Takes a FossHub URL and returns the generated
 # expiring download link for the file.
 #
-# Usage: Get-UrlFromFosshub genLink_url
+# Usage: Get-UrlFromFosshub url
 # Example:
 # Get-UrlFromFosshub https://www.fosshub.com/Audacity.html/audacity-win-2.1.2.exe
 
 Function Get-UrlFromFosshub($linkUrl) {
 
   $fosshubAppName = $linkUrl -match 'fosshub.com/(.*)/(.*)'
-  # If there’s no match, it means that it’s not a FossHub genLink URL.
+  # If there’s no match, it means that it’s not a FossHub URL.
   # Then this function simply returns the input URL.
   if (!$Matches) {
     return $linkUrl


### PR DESCRIPTION
I don't know if this is something you want to do but it would probably save some user frustration with package maintainers that haven't updated download URLs to move away from ones that use the genLink web service.  I tested with the existing IrfanView (still uses genLink) and Audacity (does not use genLink) packages.