### PR TITLE
(suggestion) Updated editorconfig and gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,8 @@
 root = true
 
-[*.nuspec]
+[*]
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
@@ -10,19 +10,6 @@ trim_trailing_whitespace = true
 
 [*.ps1]
 charset = utf-8-bom
-end_of_line = crlf
-insert_final_newline = true
-indent_style = space
-indent_size = 2
-trim_trailing_whitespace = true
 
-[*.ketarin.xml]
-charset = utf-8
-end_of_line = crlf
-insert_final_newline = true
-indent_style = space
-indent_size = 2
-trim_trailing_whitespace = true
-
-# Note: This configuration is not DRY, but currently editorconfig-sublime has
-# problems with multiple strings matching
+[*.nuspec]
+end_of_line = lf # Possibly have crlf for this as well (believe AU uses Windows Line Endings and utf-8-bom)

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,11 @@
-# Generally disable end of line conversion,
-# which overrides the settings of core.autocrlf
+* text eol=crlf whitespace=trailing-space,tab-in-indent,tabwidth=2
 
-* -text
+# Possibly have crlf for this as well (believe AU uses Windows Line Endings and utf-8-bom)
+*.nuspec text eol=lf
+
+*.png binary
+*.jpg binary
+*.exe binary
+*.dll binary
+*.zip binary
+*.cer binary


### PR DESCRIPTION
Updated .editorconfig to get rid of the duplicated rules, as well as apply to all opened text files.

Updated .gitattributes file to normalize text files to crlf line endings, except for nuspec should normalize to lf line endings.
Added some basic (really basic) whitespace error checking when running `git diff`