### PR TITLE
Use proxy settings for downloading locale list

### DIFF
--- a/automatic/Firefox/tools/chocolateyInstall.ps1
+++ b/automatic/Firefox/tools/chocolateyInstall.ps1
@@ -29,7 +29,12 @@ function GetUninstallPath () {
 
 function GetLocale() {
 
-  $availableLocales = (New-Object System.Net.WebClient).DownloadString($allLocalesListURL)
+  $webclient = New-Object System.Net.WebClient
+  $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+  $proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+  $webclient.Proxy = $proxy
+
+  $availableLocales = $webclient.DownloadString($allLocalesListURL)
 
   # --- Get locale from installArgs if specified
 


### PR DESCRIPTION
The download failed for me when trying to install it behind a corporate proxy.

It simply couldn't download the locale list and so the whole installation wasn't possible.
This should solve the issue.