### PR TITLE
[Firefox] The 64bits detection is overridden in all cases

### DIFF
--- a/automatic/Firefox/tools/chocolateyUninstall.ps1
+++ b/automatic/Firefox/tools/chocolateyUninstall.ps1
@@ -6,13 +6,13 @@ $silentArgs = '-ms'
   $regUninstallDir = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\'
   $regUninstallDirWow64 = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\'
   
+  $uninstallPaths = $(Get-ChildItem $regUninstallDir).Name
+  
   if ( Get-ProcessorBits 64 ) {
       if (Test-Path $regUninstallDirWow64) {
         $uninstallPaths += $(Get-ChildItem $regUninstallDirWow64).Name
       }
   }
-  
-  $uninstallPaths = $(Get-ChildItem $regUninstallDir).Name
 
   $uninstallPath = $uninstallPaths -match
     "Mozilla Firefox [\d\.]+ \([^\s]+ [a-zA-Z\-]+\)" | Select -First 1


### PR DESCRIPTION
The variable `$uninstallPaths` gets overridden whatever the 64bits detection could be. Prevent that.
