### PR TITLE
kb2999226: fixed a few scenarios, simplified code

### DIFF
--- a/manual/kb2999226/kb2999226.nuspec
+++ b/manual/kb2999226/kb2999226.nuspec
@@ -11,13 +11,13 @@
     <projectUrl>https://support.microsoft.com/en-us/kb/2999226</projectUrl>
     <iconUrl>https://assets.onestore.ms/cdnfiles/onestorerolling-1509-17011/shell/v1_2/images/logo/microsoft.png</iconUrl>
     <description>The Windows 10 Universal CRT is a Windows operating system component that enables CRT functionality on the Windows operating system. This update allows Windows desktop applications that depend on the Windows 10 Universal CRT release to run on earlier Windows operating systems.
-	Microsoft Visual Studio 2015 creates a dependency on the Universal CRT when applications are built by using the Windows 10 Software Development Kit (SDK). You can install this update on earlier Windows operating systems to enable these applications to run correctly.
-	This update applies to the following operating systems: Windows Server 2012 R2 Datacenter, Windows Server 2012 R2 Standard, Windows Server 2012 R2 Essentials, Windows Server 2012 R2 Foundation, Windows 8.1 Enterprise, Windows 8.1 Pro, Windows 8.1, Windows RT 8.1, Windows Server 2012 Datacenter, Windows Server 2012 Standard, Windows Server 2012 Essentials, Windows Server 2012 Foundation, Windows 8 Enterprise, Windows 8 Pro, Windows 8, Windows RT, Windows Server 2008 R2 Service Pack 1, Windows 7 Service Pack 1, Windows Server 2008 Service Pack 2, Windows Vista Service Pack 2</description>
+    Microsoft Visual Studio 2015 creates a dependency on the Universal CRT when applications are built by using the Windows 10 Software Development Kit (SDK). You can install this update on earlier Windows operating systems to enable these applications to run correctly.
+    This update applies to the following operating systems: Windows Server 2012 R2 Datacenter, Windows Server 2012 R2 Standard, Windows Server 2012 R2 Essentials, Windows Server 2012 R2 Foundation, Windows 8.1 Enterprise, Windows 8.1 Pro, Windows 8.1, Windows RT 8.1, Windows Server 2012 Datacenter, Windows Server 2012 Standard, Windows Server 2012 Essentials, Windows Server 2012 Foundation, Windows 8 Enterprise, Windows 8 Pro, Windows 8, Windows RT, Windows Server 2008 R2 Service Pack 1, Windows 7 Service Pack 1, Windows Server 2008 Service Pack 2, Windows Vista Service Pack 2</description>
     <summary>Update for Universal C Runtime (CRT) in Windows. Before you install this update, check out the prerequisites section.</summary>
     <releaseNotes>10/13/2015 18:34:00 - Revision: 3.0</releaseNotes>
     <tags>Microsoft Visual Studio 2015 Windows Update KB2919355</tags>
     <dependencies>
       <dependency id="kb2919355" version="1.0.20160915" />
-	  </dependencies>
+    </dependencies>
   </metadata>
 </package>

--- a/manual/kb2999226/kb2999226.nuspec
+++ b/manual/kb2999226/kb2999226.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>KB2999226</id>
-    <version>1.0.20161023</version>
+    <version>1.0.20161030</version>
     <title>Update for Universal C Runtime in Windows (KB2999226)</title>
     <authors>Microsoft</authors>
     <owners>RB chocolatey</owners>
@@ -14,7 +14,7 @@
     Microsoft Visual Studio 2015 creates a dependency on the Universal CRT when applications are built by using the Windows 10 Software Development Kit (SDK). You can install this update on earlier Windows operating systems to enable these applications to run correctly.
     This update applies to the following operating systems: Windows Server 2012 R2 Datacenter, Windows Server 2012 R2 Standard, Windows Server 2012 R2 Essentials, Windows Server 2012 R2 Foundation, Windows 8.1 Enterprise, Windows 8.1 Pro, Windows 8.1, Windows RT 8.1, Windows Server 2012 Datacenter, Windows Server 2012 Standard, Windows Server 2012 Essentials, Windows Server 2012 Foundation, Windows 8 Enterprise, Windows 8 Pro, Windows 8, Windows RT, Windows Server 2008 R2 Service Pack 1, Windows 7 Service Pack 1, Windows Server 2008 Service Pack 2, Windows Vista Service Pack 2</description>
     <summary>Update for Universal C Runtime (CRT) in Windows. Before you install this update, check out the prerequisites section.</summary>
-    <releaseNotes>10/13/2015 18:34:00 - Revision: 3.0</releaseNotes>
+    <releaseNotes>1.0.20161030: fixed installation on a few specific OS versions; added checking for requisite Service Packs; simplified install script</releaseNotes>
     <tags>Microsoft Visual Studio 2015 Windows Update KB2919355</tags>
     <dependencies>
       <dependency id="kb2919355" version="1.0.20160915" />

--- a/manual/kb2999226/tools/chocolateyinstall.ps1
+++ b/manual/kb2999226/tools/chocolateyinstall.ps1
@@ -68,24 +68,13 @@
 							return
 						}
 						'6.0.6002' {
-							# Windows vista
+							# Windows Vista w/ SP2 & Windows Server 2008 w/ SP2
 							Write-Host $matching
 							#32
 							$url = 'https://download.microsoft.com/download/D/8/3/D838D576-232C-4C17-A402-75913F27113B/Windows6.0-KB2999226-x86.msu'
 							$checksum = 'AE380F63BF4E8700ADA686406B04B01230A339B09EDF7819814A4C0BF4AB72E1'
 							#64
 							$url64 = 'https://download.microsoft.com/download/5/4/E/54E27BE2-CFB2-4FC9-AB03-C39302CA68A0/Windows6.0-KB2999226-x64.msu'
-							$checksum64 = '10069DE7315CA3F405E2579846AF5DAB3089A8496AE4C1AB61763480F43A05A8'
-							return
-						}
-						'6.0.6001' {
-							# Windows Server 2008
-							Write-Host $matching
-							#32
-							$url = 'https://download.microsoft.com/download/B/5/7/B5757251-DAB0-4E23-AA46-ABC233FDB90E/Windows6.0-KB2999226-x86.msu'
-							$checksum = 'AE380F63BF4E8700ADA686406B04B01230A339B09EDF7819814A4C0BF4AB72E1'
-							#64
-							$url64 = 'https://download.microsoft.com/download/A/7/A/A7A70B17-ADF9-4FC3-A722-69FA89B79756/Windows6.0-KB2999226-x64.msu'
 							$checksum64 = '10069DE7315CA3F405E2579846AF5DAB3089A8496AE4C1AB61763480F43A05A8'
 							return
 						}

--- a/manual/kb2999226/tools/chocolateyinstall.ps1
+++ b/manual/kb2999226/tools/chocolateyinstall.ps1
@@ -5,10 +5,10 @@ $proceed = $false
 $silentArgs = "/quiet /norestart /log:`"$env:TEMP\$kb.Install.evt`""
 # OS Information
 $os = Get-WmiObject -Class Win32_OperatingSystem
-$caption = $os.Caption
+$caption = $os.Caption.Trim()
 $sp = $os.ServicePackMajorVersion
 if ($sp -gt 0) {
-	$caption += "Service Pack $sp"
+	$caption += " Service Pack $sp"
 }
 # Messages for the Consumer
 $skippingNotApplies = "Skipping installation because hotfix $kb does not apply to $caption.`n"

--- a/manual/kb2999226/tools/chocolateyinstall.ps1
+++ b/manual/kb2999226/tools/chocolateyinstall.ps1
@@ -11,8 +11,8 @@
 		$os = Get-WmiObject -Class Win32_OperatingSystem
 		$caption = $os.Caption
 		$sp = $os.ServicePackMajorVersion
-		if ($sp -eq '1') {
-		$caption += "Service Pack 1"
+		if ($sp -gt 0) {
+		$caption += "Service Pack $sp"
 		}
 		# Messages for the Consumer
 		$proceeding = "Proceding with installation because this hotfix applies to $caption.`n"

--- a/manual/kb2999226/tools/chocolateyinstall.ps1
+++ b/manual/kb2999226/tools/chocolateyinstall.ps1
@@ -21,7 +21,6 @@
 		$fini_yes = "This $kb has been installed on your $caption.`n"
 		$fini_no = "This $kb does not Apply to your $caption.`n"
 
-	Try {
 		foreach ( $detected in $AppliesTo  ) {
 			if ( $detected -eq $caption ) {
 				Write-Host $proceeding
@@ -43,7 +42,6 @@
 							#64
 							$url64 = 'https://download.microsoft.com/download/D/1/3/D13E3150-3BB2-4B22-9D8A-47EE2D609FFF/Windows8.1-KB2999226-x64.msu'
 							$checksum64 = '9F707096C7D279ED4BC2A40BA695EFAC69C20406E0CA97E2B3E08443C6381D15'
-							return
 						}
 						'6.2.9200' {
 							# Windows 8.0 & Windows Server 2012
@@ -54,7 +52,6 @@
 							#64
 							$url64 = 'https://download.microsoft.com/download/9/3/E/93E0745A-EAE9-4B5A-B50C-012F2D3B6659/Windows8-RT-KB2999226-x64.msu'
 							$checksum64 = '50CAE25DA33FA950222D1A803E42567291EB7FEB087FA119B1C97FE9D41CD9F8'
-							return
 						}
 						'6.1.7601' {
 							# Windows 7 w/ SP1 & Windows Server 2008 R2 w/ SP1
@@ -65,7 +62,9 @@
 							#64
 							$url64 = 'https://download.microsoft.com/download/F/1/3/F13BEC9A-8FC6-4489-9D6A-F84BDC9496FE/Windows6.1-KB2999226-x64.msu'
 							$checksum64 = '43234D2986CA9B0DE75D5183977964D161A8395C3396279DDFC9B20698E5BC34'
-							return
+						}
+						'6.1.7600' {
+							throw "To install $kb on $caption, you must install Service Pack 1 first, for example using the KB976932 package."
 						}
 						'6.0.6002' {
 							# Windows Vista w/ SP2 & Windows Server 2008 w/ SP2
@@ -76,16 +75,19 @@
 							#64
 							$url64 = 'https://download.microsoft.com/download/5/4/E/54E27BE2-CFB2-4FC9-AB03-C39302CA68A0/Windows6.0-KB2999226-x64.msu'
 							$checksum64 = '10069DE7315CA3F405E2579846AF5DAB3089A8496AE4C1AB61763480F43A05A8'
-							return
 						}
-						default { Write-Warning "Running on unsupported Operating System.  No installation will take place."; return}
+						'6.0.6001' {
+							throw "To install $kb on $caption, you must install Service Pack 2 first."
+						}
+						'6.0.6000' {
+							throw "To install $kb on $caption, you must install Service Pack 2 first."
+						}
+						default { Write-Warning "Running on unsupported Operating System.  No installation will take place." }
 					}
 				}
 			}
 
 		}
-	}
-	Finally {
 		if ($proceed) {
 				$packageArgs = @{
 				packageName   = $packageName
@@ -105,4 +107,3 @@
 		} else {
 		Write-Host $fini_no
 		}
-	}

--- a/manual/kb2999226/tools/chocolateyinstall.ps1
+++ b/manual/kb2999226/tools/chocolateyinstall.ps1
@@ -1,92 +1,90 @@
-﻿
+﻿# Variables
+$kb = "kb2999226"
+$packageName = $kb
+$proceed = $false
+$silentArgs = "/quiet /norestart /log:`"$env:TEMP\$kb.Install.evt`""
+# OS Information
+$os = Get-WmiObject -Class Win32_OperatingSystem
+$caption = $os.Caption
+$sp = $os.ServicePackMajorVersion
+if ($sp -gt 0) {
+	$caption += "Service Pack $sp"
+}
+# Messages for the Consumer
+$skippingNotApplies = "Skipping installation because hotfix $kb does not apply to $caption.`n"
+$skippingAlreadyInstalled = "Skipping installation because hotfix $kb is already installed.`n"
+$matching = "You are using $caption, and do qualify for the $kb.`n"
 
-		# Variables
-		$kb = "kb2999226"
-		$packageName = $kb
-		$proceed = $false
-		$silentArgs = "/quiet /norestart /log:`"$env:TEMP\$kb.Install.evt`""
-		# OS Information
-		$os = Get-WmiObject -Class Win32_OperatingSystem
-		$caption = $os.Caption
-		$sp = $os.ServicePackMajorVersion
-		if ($sp -gt 0) {
-		$caption += "Service Pack $sp"
-		}
-		# Messages for the Consumer
-		$skippingNotApplies = "Skipping installation because hotfix $kb does not apply to $caption.`n"
-		$skippingAlreadyInstalled = "Skipping installation because hotfix $kb is already installed.`n"
-		$matching = "You are using $caption, and do qualify for the $kb.`n"
+switch -Exact ($os.Version) {
+	'6.3.9600' {
+		# Windows 8.1 & Windows Server 2012 R2
+		Write-Host $matching
+		#32
+		$url = 'https://download.microsoft.com/download/E/4/6/E4694323-8290-4A08-82DB-81F2EB9452C2/Windows8.1-KB2999226-x86.msu'
+		$checksum = 'B83251219C5390536B02BEBAF5E43A6F13381CE1DB43E76483BCE07C4BCF877B'
+		#64
+		$url64 = 'https://download.microsoft.com/download/D/1/3/D13E3150-3BB2-4B22-9D8A-47EE2D609FFF/Windows8.1-KB2999226-x64.msu'
+		$checksum64 = '9F707096C7D279ED4BC2A40BA695EFAC69C20406E0CA97E2B3E08443C6381D15'
+	}
+	'6.2.9200' {
+		# Windows 8.0 & Windows Server 2012
+		Write-Host $matching
+		#32
+		$url = 'https://download.microsoft.com/download/1/E/8/1E8AFE90-5217-464D-9292-7D0B95A56CE4/Windows8-RT-KB2999226-x86.msu'
+		$checksum = '0F36750FBB06FEE23131F68B4D0943841EED24730EC1D5D77DEDC41D359BE88D'
+		#64
+		$url64 = 'https://download.microsoft.com/download/9/3/E/93E0745A-EAE9-4B5A-B50C-012F2D3B6659/Windows8-RT-KB2999226-x64.msu'
+		$checksum64 = '50CAE25DA33FA950222D1A803E42567291EB7FEB087FA119B1C97FE9D41CD9F8'
+	}
+	'6.1.7601' {
+		# Windows 7 w/ SP1 & Windows Server 2008 R2 w/ SP1
+		Write-Host $matching
+		#32
+		$url = 'https://download.microsoft.com/download/4/F/E/4FE73868-5EDD-4B47-8B33-CE1BB7B2B16A/Windows6.1-KB2999226-x86.msu'
+		$checksum = '909E76C81EF0EB176144B253DDFFE7A8FDFACEBFAA15E97DEF003D2262FBF084'
+		#64
+		$url64 = 'https://download.microsoft.com/download/F/1/3/F13BEC9A-8FC6-4489-9D6A-F84BDC9496FE/Windows6.1-KB2999226-x64.msu'
+		$checksum64 = '43234D2986CA9B0DE75D5183977964D161A8395C3396279DDFC9B20698E5BC34'
+	}
+	'6.1.7600' {
+		throw "To install $kb on $caption, you must install Service Pack 1 first, for example using the KB976932 package."
+	}
+	'6.0.6002' {
+		# Windows Vista w/ SP2 & Windows Server 2008 w/ SP2
+		Write-Host $matching
+		#32
+		$url = 'https://download.microsoft.com/download/D/8/3/D838D576-232C-4C17-A402-75913F27113B/Windows6.0-KB2999226-x86.msu'
+		$checksum = 'AE380F63BF4E8700ADA686406B04B01230A339B09EDF7819814A4C0BF4AB72E1'
+		#64
+		$url64 = 'https://download.microsoft.com/download/5/4/E/54E27BE2-CFB2-4FC9-AB03-C39302CA68A0/Windows6.0-KB2999226-x64.msu'
+		$checksum64 = '10069DE7315CA3F405E2579846AF5DAB3089A8496AE4C1AB61763480F43A05A8'
+	}
+	'6.0.6001' {
+		throw "To install $kb on $caption, you must install Service Pack 2 first."
+	}
+	'6.0.6000' {
+		throw "To install $kb on $caption, you must install Service Pack 2 first."
+	}
+	default {
+		Write-Host $skippingNotApplies
+	}
+}
+if (Get-HotFix -Id $kb -ErrorAction SilentlyContinue) {
+	Write-Host $skippingAlreadyInstalled
+	return
+}
 
-					switch -Exact($os.version) {
-						'6.3.9600' {
-							# Windows 8.1 & Windows Server 2012 R2
-							Write-Host $matching
-							#32
-							$url = 'https://download.microsoft.com/download/E/4/6/E4694323-8290-4A08-82DB-81F2EB9452C2/Windows8.1-KB2999226-x86.msu'
-							$checksum = 'B83251219C5390536B02BEBAF5E43A6F13381CE1DB43E76483BCE07C4BCF877B'
-							#64
-							$url64 = 'https://download.microsoft.com/download/D/1/3/D13E3150-3BB2-4B22-9D8A-47EE2D609FFF/Windows8.1-KB2999226-x64.msu'
-							$checksum64 = '9F707096C7D279ED4BC2A40BA695EFAC69C20406E0CA97E2B3E08443C6381D15'
-						}
-						'6.2.9200' {
-							# Windows 8.0 & Windows Server 2012
-							Write-Host $matching
-							#32
-							$url = 'https://download.microsoft.com/download/1/E/8/1E8AFE90-5217-464D-9292-7D0B95A56CE4/Windows8-RT-KB2999226-x86.msu'
-							$checksum = '0F36750FBB06FEE23131F68B4D0943841EED24730EC1D5D77DEDC41D359BE88D'
-							#64
-							$url64 = 'https://download.microsoft.com/download/9/3/E/93E0745A-EAE9-4B5A-B50C-012F2D3B6659/Windows8-RT-KB2999226-x64.msu'
-							$checksum64 = '50CAE25DA33FA950222D1A803E42567291EB7FEB087FA119B1C97FE9D41CD9F8'
-						}
-						'6.1.7601' {
-							# Windows 7 w/ SP1 & Windows Server 2008 R2 w/ SP1
-							Write-Host $matching
-							#32
-							$url = 'https://download.microsoft.com/download/4/F/E/4FE73868-5EDD-4B47-8B33-CE1BB7B2B16A/Windows6.1-KB2999226-x86.msu'
-							$checksum = '909E76C81EF0EB176144B253DDFFE7A8FDFACEBFAA15E97DEF003D2262FBF084'
-							#64
-							$url64 = 'https://download.microsoft.com/download/F/1/3/F13BEC9A-8FC6-4489-9D6A-F84BDC9496FE/Windows6.1-KB2999226-x64.msu'
-							$checksum64 = '43234D2986CA9B0DE75D5183977964D161A8395C3396279DDFC9B20698E5BC34'
-						}
-						'6.1.7600' {
-							throw "To install $kb on $caption, you must install Service Pack 1 first, for example using the KB976932 package."
-						}
-						'6.0.6002' {
-							# Windows Vista w/ SP2 & Windows Server 2008 w/ SP2
-							Write-Host $matching
-							#32
-							$url = 'https://download.microsoft.com/download/D/8/3/D838D576-232C-4C17-A402-75913F27113B/Windows6.0-KB2999226-x86.msu'
-							$checksum = 'AE380F63BF4E8700ADA686406B04B01230A339B09EDF7819814A4C0BF4AB72E1'
-							#64
-							$url64 = 'https://download.microsoft.com/download/5/4/E/54E27BE2-CFB2-4FC9-AB03-C39302CA68A0/Windows6.0-KB2999226-x64.msu'
-							$checksum64 = '10069DE7315CA3F405E2579846AF5DAB3089A8496AE4C1AB61763480F43A05A8'
-						}
-						'6.0.6001' {
-							throw "To install $kb on $caption, you must install Service Pack 2 first."
-						}
-						'6.0.6000' {
-							throw "To install $kb on $caption, you must install Service Pack 2 first."
-						}
-						default {
-							Write-Host $skippingNotApplies
-						}
-					}
-				if (Get-HotFix -Id $kb -ErrorAction SilentlyContinue) {
-					Write-Host $skippingAlreadyInstalled
-					return
-				}
-
-				$packageArgs = @{
-				packageName   = $packageName
-				fileType      = 'msu'
-				url           = $url
-				url64bit      = $url64
-				silentArgs    = $silentArgs
-				validExitCodes= @(0, 3010, 0x80240017)
-				softwareName  = $packageName
-				checksum      = $checksum
-				checksumType  = 'sha256'
-				checksum64    = $checksum64
-				checksumType64= 'sha256'
-				}
-				Install-ChocolateyPackage @packageArgs
+$packageArgs = @{
+	packageName   = $packageName
+	fileType      = 'msu'
+	url           = $url
+	url64bit      = $url64
+	silentArgs    = $silentArgs
+	validExitCodes= @(0, 3010, 0x80240017)
+	softwareName  = $packageName
+	checksum      = $checksum
+	checksumType  = 'sha256'
+	checksum64    = $checksum64
+	checksumType64= 'sha256'
+}
+Install-ChocolateyPackage @packageArgs

--- a/manual/kb2999226/tools/chocolateyinstall.ps1
+++ b/manual/kb2999226/tools/chocolateyinstall.ps1
@@ -23,12 +23,12 @@
 
 	Try {
 		foreach ( $detected in $AppliesTo  ) {
-		   if ( $detected -eq $caption ) {
+			if ( $detected -eq $caption ) {
 				Write-Host $proceeding
 				$proceed = $true
 				if (Get-HotFix -id $kb -ea SilentlyContinue) {
 					Write-Host $skipping
-                    $proceed = $false
+					$proceed = $false
 					return
 				}
 


### PR DESCRIPTION
Fixed installation on:
- Vista/2008 SP2
- Evaluation editions (e.g. "Microsoft Windows Server 2012 R2 Datacenter Evaluation") and, possibly, other less-known named editions

New feature: detecting lack of the requisite Service Pack on Vista/2008/7/2008 R2 (and suggesting the Chocolatey package for 7/2008 R2 SP1)

Code cleanup:
- simplified control flow
- fixed indentation

