### PR TITLE
(Update-IconUrl.ps1) Fixed Test-Path returning add and commit messages

### DIFF
--- a/setup/Update-IconUrl.ps1
+++ b/setup/Update-IconUrl.ps1
@@ -112,8 +112,8 @@ function Test-Icon{
   $path = "$IconDir/$Name.$Extension"
   if (!(Test-Path $path)) { return $false; }
   if ((git status "$path" -s)) {
-    git add $path;
-    git commit -m "Added/Updated $Name icon" "$path";
+    git add $path | Out-Null;
+    git commit -m "Added/Updated $Name icon" "$path" | Out-Null;
   }
 
   return git log -1 --format="%H" "$path";


### PR DESCRIPTION
if the found icon hasn't already been added and committed
the Test-Path function incorrectly returned
the message from both `git add` and `git commit`