### PR TITLE
(codeblocks) Removing unnecessary dependency

### DIFF
--- a/automatic/codeblocks/codeblocks.nuspec
+++ b/automatic/codeblocks/codeblocks.nuspec
@@ -31,7 +31,6 @@ This package downloads the installer with the included GCC compiler.
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/codeblocks</packageSourceUrl>
     <dependencies>
       <dependency id="chocolatey-fosshub.extension" version="0.2.0" />
-      <dependency id="chocolatey-core.extension" version="1.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/codeblocks/update.ps1
+++ b/automatic/codeblocks/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 import-module "$PSScriptRoot/../../extensions/chocolatey-fosshub.extension/extensions/Get-UrlFromFosshub.psm1"
-import-module "$PSScriptRoot/../../extensions/chocolatey-core.extension/extensions/Get-WebContent.psm1"
+. "$PSScriptRoot/../../extensions/chocolatey-core.extension/extensions/Get-WebContent.ps1"
 
 $releases = 'http://www.codeblocks.org/downloads/26'
 


### PR DESCRIPTION
@majkinetor @AdmiringWorm why was this extra dependency required?  The fosshub extension already has a dependency on the core extension, and should be resolved that way.