### PR TITLE
virtualbox - variable missing

### DIFF
--- a/automatic/virtualbox/tools/chocolateyInstall.ps1
+++ b/automatic/virtualbox/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 $cert = ls cert: -Recurse | ? { $_.Thumbprint -eq 'a88fd9bdaa06bc0f3c491ba51e231be35f8d1ad5' }
 if (!$cert) {
     $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
-    Start-ChocolateyProcessAsAdmin "certutil -addstore 'TrustedPublisher' '$tools\oracle.cer'"
+    Start-ChocolateyProcessAsAdmin "certutil -addstore 'TrustedPublisher' '$toolsPath\oracle.cer'"
 }
 
 $packageArgs = @{


### PR DESCRIPTION
Looks like this needed to be $toolsPath.

This will need a new package fix version notation package version purshed. @majkinetor @AdmiringWorm 


cc @wget 