### PR TITLE
smartftp: added KB2670838 dependency

### DIFF
--- a/automatic/smartftp/smartftp.nuspec
+++ b/automatic/smartftp/smartftp.nuspec
@@ -60,6 +60,7 @@ SmartFTP is a fast and reliable FTP, FTPS, SFTP, HTTP, Amazon S3, WebDAV, Google
     <dependencies>
       <dependency id="vcredist2017" />
       <dependency id="KB2533623" />
+      <dependency id="KB2670838" version="1.0.0" />
     </dependencies>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/smartftp</packageSourceUrl>
     <docsUrl>https://www.smartftp.com/support</docsUrl>


### PR DESCRIPTION
SmartFTP depends on KB2670838 on Windows 7, Windows Server 2008 R2.