### PR TITLE
smartftp: added missing versions to dependencies

### DIFF
--- a/automatic/smartftp/smartftp.nuspec
+++ b/automatic/smartftp/smartftp.nuspec
@@ -58,8 +58,8 @@ SmartFTP is a fast and reliable FTP, FTPS, SFTP, HTTP, Amazon S3, WebDAV, Google
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/97d1e867fd5feaee1b89b24ffe6d40c22c819dc3/icons/smartftp.svg</iconUrl>
     <bugTrackerUrl>https://www.smartftp.com/forums/index.php?/forum/14-support/</bugTrackerUrl>
     <dependencies>
-      <dependency id="vcredist2017" />
-      <dependency id="KB2533623" />
+      <dependency id="vcredist2017" version="14.10.24629.0-rc1" />
+      <dependency id="KB2533623" version="1.0.0" />
       <dependency id="KB2670838" version="1.0.0" />
     </dependencies>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/smartftp</packageSourceUrl>


### PR DESCRIPTION
To comply with the guidelines, the min version numbers have been added now.