### PR TITLE
(foshub.extension) Fixed fosshub parsing to find the download url in any attribute [PUSH chocolatey-fosshub.extension]

### DIFF
--- a/automatic/audacity/audacity.nuspec
+++ b/automatic/audacity/audacity.nuspec
@@ -21,7 +21,7 @@ See [full list of features](http://www.audacityteam.org/about/features).
     <releaseNotes></releaseNotes>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
     <dependencies>
-      <dependency id="chocolatey-fosshub.extension" version="0.5.0" />
+      <dependency id="chocolatey-fosshub.extension" version="0.6.0" />
     </dependencies>
     <docsUrl>http://www.audacityteam.org/help/documentation</docsUrl>
     <projectSourceUrl>https://github.com/audacity/audacity</projectSourceUrl>

--- a/automatic/avidemux/avidemux.nuspec
+++ b/automatic/avidemux/avidemux.nuspec
@@ -22,7 +22,7 @@ Avidemux is available for Linux, BSD, Mac OS X and Microsoft Windows under the G
     <tags>video editor foss cutting filtering encoding admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
     <dependencies>
-      <dependency id="chocolatey-fosshub.extension" version="0.5.0" />
+      <dependency id="chocolatey-fosshub.extension" version="0.6.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/codeblocks/codeblocks.nuspec
+++ b/automatic/codeblocks/codeblocks.nuspec
@@ -30,7 +30,7 @@ This package downloads the installer with the included GCC compiler.
     <tags>codeblocks C++ IDE admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/codeblocks</packageSourceUrl>
     <dependencies>
-      <dependency id="chocolatey-fosshub.extension" version="0.5.0" />
+      <dependency id="chocolatey-fosshub.extension" version="0.6.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/lightalloy/lightalloy.nuspec
+++ b/automatic/lightalloy/lightalloy.nuspec
@@ -21,7 +21,7 @@ _The installer is not silent. I've used AutoIt to automate the installation. Be 
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/e4a49519947c3cff55c17a0b08266c56b0613e64/icons/lightalloy.png</iconUrl>
     <dependencies>
       <dependency id="autoit.commandline" version="3.3.12.0" />
-      <dependency id="chocolatey-fosshub.extension" version="0.5.0" />
+      <dependency id="chocolatey-fosshub.extension" version="0.6.0" />
     </dependencies>
     <releaseNotes></releaseNotes>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>

--- a/automatic/mkvtoolnix/mkvtoolnix.nuspec
+++ b/automatic/mkvtoolnix/mkvtoolnix.nuspec
@@ -20,7 +20,7 @@ With these tools one can get information about (mkvinfo) Matroska files, extract
     <tags>multimedia mkv container muxing demuxing admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
     <dependencies>
-      <dependency id="chocolatey-fosshub.extension" version="0.5.0" />
+      <dependency id="chocolatey-fosshub.extension" version="0.6.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/qbittorrent/qbittorrent.nuspec
+++ b/automatic/qbittorrent/qbittorrent.nuspec
@@ -25,7 +25,7 @@ qBittorrent aims to have a small foot-print, to be powerful, intuitive and visua
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/edba4a5849ff756e767cba86641bea97ff5721fe/icons/qbittorrent.png</iconUrl>
     <releaseNotes>http://www.qbittorrent.org/news.php</releaseNotes>
     <dependencies>
-      <dependency id="chocolatey-fosshub.extension" version="0.5.0" />
+      <dependency id="chocolatey-fosshub.extension" version="0.6.0" />
     </dependencies>
   </metadata>
   <files>

--- a/extensions/chocolatey-fosshub.extension/chocolatey-fosshub.extension.nuspec
+++ b/extensions/chocolatey-fosshub.extension/chocolatey-fosshub.extension.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chocolatey-fosshub.extension</id>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
     <owners>chocolatey</owners>
     <title>Chocolatey FossHub Extension</title>

--- a/extensions/chocolatey-fosshub.extension/extensions/Get-UrlFromFosshub.psm1
+++ b/extensions/chocolatey-fosshub.extension/extensions/Get-UrlFromFosshub.psm1
@@ -30,9 +30,9 @@ Function Get-UrlFromFosshub($linkUrl) {
 
   # Construct the Regular Expression pattern.  An example of what is being searched for is this
   # <a href="/Audacity.html/audacity-win-2.1.2.exe" rel="nofollow" class="dwl-link xlink" file="audacity-win-2.1.2.exe" xdts="https://download.fosshub.com/Protected/expiretime=1480500963;badurl=aHR0cDovL3d3dy5mb3NzaHViLmNvbS9BdWRhY2l0eS5odG1s/5cd3862bc6dd39508c537b1ad21a0bdc2e7d46dd4c64d182cfb6a819d0ef20a1/Audacity/audacity-win-2.1.2.exe">
-  $regexPattern = "<a href=`"$hrefText`".*(?:data|xdts)=`"(.*)`""
+  $regexPattern = "<a href=`"$hrefText`"[^>]+=`"(https:\/\/download\.fosshub\.com\/[^`"]+)`""
 
-  $opts = @{ Headers = @{ Referer = 'https://www.fosshub.com/${fosshubAppName}' } }
+  $opts = @{ Headers = @{ Referer = "https://www.fosshub.com/${fosshubAppName}" } }
   $htmlPage = Get-WebContent -url $linkUrl -options $opts
 
   $dataLink = $htmlPage -match $regexPattern


### PR DESCRIPTION
fixes #414

While debugging I noticed the referrer was being sent as a literal string - changed quotes.
Tested working with an update of my local audacity install on Win8.1.
I should say I'm not too familiar with PowerShell syntax, so please let me know if there's anything in the regex that might break it (in older PS versions etc).