### PR TITLE
(chocolatey-core.extension) Guard loading Register-Application

### DIFF
--- a/extensions/chocolatey-core.extension/extensions/Register-Application.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Register-Application.ps1
@@ -1,3 +1,9 @@
+if ((Get-Command Register-Application -ErrorAction SilentlyContinue))
+{
+  Write-Debug "Register-Application already loaded from a different extension or possibly built into Chocolatey. Not loading function with Chocolatey-Core.Extension."
+  return
+}
+
 <#
 .SYNOPSIS
     Register application in the system


### PR DESCRIPTION
When Register-Application is already loaded by other means, write a 
debug message for debugging purposes but don't load the extension.

Relates to #454 

This is an example of what I'm looking for with extension function loading.