### PR TITLE
(poweriso) Changed to get the actual URL during install

### DIFF
--- a/automatic/poweriso/tools/chocolateyInstall.ps1
+++ b/automatic/poweriso/tools/chocolateyInstall.ps1
@@ -1,16 +1,22 @@
 $ErrorActionPreference = 'Stop'
 
+import-module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
+
+$download_content = Get-WebContent 'http://www.poweriso.com/download.htm'
+
+$reMatches = [regex]::Matches($download_content, '\<a class="download_link" href="([^"]+)"')
+
 $packageArgs = @{
   packageName            = 'poweriso'
   fileType               = 'exe'
-  url                    = 'http://www.universedlgift.com/+zQNrYiOhVsbCLkAQaGhwajksYhG4YiAEkAzPwFdxjX3GdYt1q+ELdClaOYJZM2P++i8R4lMT58xrYWTiGAcvo5hE4+eS0RvJl6oZvZIxYG3k2TtUa2AfTGA6VGE+VFlADYPjqBFc07Xzr3slzv6z_E4PBZ_dg==-G0oAAGRsXWvX4IeysG7DBhw4lUlAtuOwMXau4HEXNRYU6s7hF+KO241fppgTQiFTQlUCUiK4Qam+UmB6c_MFn3OCeT_716E='
-  url64bit               = 'http://www.worldnowclear.com/TOBh6YywsrjIB7xW49H7NrO9iWoMIganz3DS6eYUNuDgJNzXQIbzBkEnWzqupb7w4Pxn07qE0aUNCQcYBqWf5PVReTc3GzZgUDljBEOnjdxTIAuqMKguq6_HdSFYpqjcS_5Vc8l4ZMw4qFsh70HKAZp9q1oGqQ==-G1EAAGTcXGs0k8TI8vu6O2zAgVOZBGQD4LAxdq7gcRc1FhTqzuEX4o7biytTqARslx9zQihkSqhKQK0oVUTpsQLTzs3nP3OCeT_711A='
+  url                    = $reMatches[0].Groups[1]
+  url64bit               = $reMatches[1].Groups[1]
   checksum               = '3a18891f5cc5f2fcf46fc1b4eda3c99ebaee4c06d4b8e6409507096d45985c76'
   checksum64             = 'b8c6a05c6322d1884f0c5347dfde9d1f95ab58218a20b9c884d3a5e78b315d8d'
   checksumType           = 'sha256'
   checksumType64         = 'sha256'
   silentArgs             = '/S'
-  validExitCodes         = @(0)
+  validExitCodes         = @(0, 4) # It somehow returns code 4 even when successful
   softwareName           = 'poweriso*'
 }
 Install-ChocolateyPackage @packageArgs

--- a/automatic/poweriso/tools/chocolateyInstall.ps1
+++ b/automatic/poweriso/tools/chocolateyInstall.ps1
@@ -14,7 +14,7 @@ $packageArgs = @{
   checksumType           = 'sha256'
   checksumType64         = 'sha256'
   silentArgs             = '/S'
-  validExitCodes         = @(0, 4) # It somehow returns code 4 even when successful
+  validExitCodes         = @(0)
   softwareName           = 'poweriso*'
 }
 Install-ChocolateyPackage @packageArgs

--- a/automatic/poweriso/tools/chocolateyInstall.ps1
+++ b/automatic/poweriso/tools/chocolateyInstall.ps1
@@ -1,7 +1,5 @@
 $ErrorActionPreference = 'Stop'
 
-import-module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
-
 $download_content = Get-WebContent 'http://www.poweriso.com/download.htm'
 
 $reMatches = [regex]::Matches($download_content, '\<a class="download_link" href="([^"]+)"')

--- a/automatic/poweriso/update.ps1
+++ b/automatic/poweriso/update.ps1
@@ -1,15 +1,12 @@
 import-module au
+import-module "$PSScriptRoot\..\..\extensions\extensions.psm1"
 
-$releases = ' http://www.poweriso.com/download.htm'
-
-function global:au_BeforeUpdate {
-  $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32
-  $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64
-}
+$releases = 'http://www.poweriso.com/download.htm'
 
 function global:au_SearchReplace {
    @{
         ".\tools\chocolateyInstall.ps1" = @{
+            "(?i)(Get\-WebContent\s*)'.*'"        = "`$1'$releases'"
             "(?i)(^\s*checksum\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum32)'"
             "(?i)(^\s*checksum64\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum64)'"
             "(?i)(^\s*packageName\s*=\s*)('.*')"  = "`$1'$($Latest.PackageName)'"
@@ -23,9 +20,7 @@ function global:au_GetLatest {
     $url = $download_page.links | ? class -eq 'download_link'
     @{
         Version = ($url[0].InnerText -split ' ' | Select -Last 1 -Skip 1).Substring(1)
-        URL32   = $url | ? InnerText -match '32-bit' | % href | select -First 1
-        URL64   = $url | ? InnerText -match '64-bit' | % href | select -First 1
     }
 }
 
-update -ChecksumFor none
+update

--- a/automatic/poweriso/update.ps1
+++ b/automatic/poweriso/update.ps1
@@ -2,11 +2,14 @@ import-module au
 
 $releases = ' http://www.poweriso.com/download.htm'
 
+function global:au_BeforeUpdate {
+  $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32
+  $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64
+}
+
 function global:au_SearchReplace {
    @{
         ".\tools\chocolateyInstall.ps1" = @{
-            "(?i)(^\s*url\s*=\s*)('.*')"          = "`$1'$($Latest.URL32)'"
-            "(?i)(^\s*url64bit\s*=\s*)('.*')"     = "`$1'$($Latest.URL64)'"
             "(?i)(^\s*checksum\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum32)'"
             "(?i)(^\s*checksum64\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum64)'"
             "(?i)(^\s*packageName\s*=\s*)('.*')"  = "`$1'$($Latest.PackageName)'"
@@ -25,4 +28,4 @@ function global:au_GetLatest {
     }
 }
 
-update
+update -ChecksumFor none


### PR DESCRIPTION
I know it isn't optimal, but this was the only way I found that we could get the correct installer.
So unless someone gets the redistribution rights from the poweriso team, this I believe will have to do.

@gep13 @majkinetor 
could you guys test the install script, without changing the hash.