### PR TITLE
(mkdocs) Check PyPi for new package releases instead of GitHub

### DIFF
--- a/automatic/mkdocs/update.ps1
+++ b/automatic/mkdocs/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$releases = 'https://github.com/mkdocs/mkdocs/releases'
+$releases = 'https://pypi.python.org/pypi/mkdocs/json'
 
 function global:au_SearchReplace {
     @{
@@ -11,16 +11,9 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases
+    $version = (Invoke-WebRequest -UseBasicParsing -Uri $releases | ConvertFrom-Json | Select -Expand info | Select version).version
 
-    #0.16.0.zip
-    $re  = "(.*).zip"
-    $url = $download_page.links | ? href -match $re | select -First 1 -expand href
-
-    $version = [IO.Path]::GetFileNameWithoutExtension($url)
-
-    $Latest = @{ Version = $version }
-    return $Latest
+    return @{ Version = $version }
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
Not all releases from GitHub are necessarily pushed to the Python Package Index from where the Chocolatey Package will install the tool.