### PR TITLE
(git-lfs*) Update release notes link for the current version

### DIFF
--- a/automatic/git-lfs.install/git-lfs.install.nuspec
+++ b/automatic/git-lfs.install/git-lfs.install.nuspec
@@ -24,7 +24,7 @@ Git Large File Storage (LFS) replaces large files such as audio samples, videos,
 * **Same access controls and permissions:** Keep the same access controls and permissions for large files as the rest of your Git repository when working with a remote host like GitHub.
 </description>
     <tags>git lfs vcs dvcs version-control admin foss cross-platform cli</tags>
-    <releaseNotes>https://github.com/github/git-lfs/blob/master/CHANGELOG.md</releaseNotes>
+    <releaseNotes>https://github.com/git-lfs/git-lfs/releases/tag/v1.5.4</releaseNotes>
     <dependencies>
       <dependency id="git" version="1.8.2" />
     </dependencies>

--- a/automatic/git-lfs.install/update.ps1
+++ b/automatic/git-lfs.install/update.ps1
@@ -23,6 +23,9 @@ function global:au_BeforeUpdate {
 
 function global:au_SearchReplace {
     @{
+        ".\git-lfs.install.nuspec" = @{
+            "(<releaseNotes>https:\/\/github.com\/git-lfs\/git-lfs\/releases\/tag\/v)(.*)(<\/releaseNotes>)" = "`${1}$($Latest.Version.ToString())`$3"
+        }
         "tools\chocolateyInstall.ps1" = @{
             "(?i)(`"`[$]toolsDir\\).*`"" = "`${1}$($Latest.FileName)`""
         }

--- a/automatic/git-lfs/git-lfs.nuspec
+++ b/automatic/git-lfs/git-lfs.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>git-lfs</id>
@@ -24,7 +24,7 @@ Git Large File Storage (LFS) replaces large files such as audio samples, videos,
 * **Same access controls and permissions:** Keep the same access controls and permissions for large files as the rest of your Git repository when working with a remote host like GitHub.
 </description>
     <tags>git lfs vcs dvcs version-control foss cross-platform cli</tags>
-    <releaseNotes>https://github.com/github/git-lfs/blob/master/CHANGELOG.md</releaseNotes>
+    <releaseNotes>https://github.com/git-lfs/git-lfs/releases/tag/v1.5.4</releaseNotes>
     <dependencies>
       <dependency id="git-lfs.install" version="[1.5.4]" />
     </dependencies>

--- a/automatic/git-lfs/update.ps1
+++ b/automatic/git-lfs/update.ps1
@@ -3,6 +3,7 @@
 function global:au_SearchReplace {
    @{
         "$($Latest.PackageName).nuspec" = @{
+            "(<releaseNotes>https:\/\/github.com\/git-lfs\/git-lfs\/releases\/tag\/v)(.*)(<\/releaseNotes>)" = "`${1}$($Latest.Version.ToString())`$3"
             "(\<dependency .+?`"$($Latest.PackageName).install`" version=)`"([^`"]+)`"" = "`$1`"[$($Latest.Version)]`""
         }
     }


### PR DESCRIPTION
The [current release notes link](https://github.com/git-lfs/git-lfs/blob/master/CHANGELOG.md) seems to be outdated (still at 1.5.0). Update release notes link to [GitHub Release Page](https://github.com/git-lfs/git-lfs/releases) and link directly to the current release.