### PR TITLE
Fixing an install issue on CutePDF Writer when print spooler service is not up and running

### DIFF
--- a/automatic/cutepdf/cutepdf.nuspec
+++ b/automatic/cutepdf/cutepdf.nuspec
@@ -6,7 +6,7 @@
     <title>CutePDF Writer</title>
     <version>3.1</version>
     <authors>Acro Software Inc.</authors>
-    <owners>Redsandro,Thilas</owners>
+    <owners>chocolatey,Redsandro,Thilas</owners>
     <summary>Free PDF printer driver with no watermarks.</summary>
     <description>
 Portable Document Format (PDF) is the de facto standard for the secure and reliable distribution and exchange of electronic documents and forms around the world.  CutePDF Writer is the free version of commercial PDF converter software. CutePDF Writer installs itself as a "printer subsystem". This enables virtually any Windows applications (must be able to print) to convert to professional quality PDF documents - with just a push of a button!

--- a/automatic/cutepdf/cutepdf.nuspec
+++ b/automatic/cutepdf/cutepdf.nuspec
@@ -3,10 +3,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>cutepdf</id>
-    <title>CutePDF</title>
-    <version>3.0</version>
+    <title>CutePDF Writer</title>
+    <version>3.1</version>
     <authors>Acro Software Inc.</authors>
-    <owners>Redsandro</owners>
+    <owners>Redsandro Thilas</owners>
     <summary>Free PDF printer driver with no watermarks.</summary>
     <description>
 Portable Document Format (PDF) is the de facto standard for the secure and reliable distribution and exchange of electronic documents and forms around the world.  CutePDF Writer is the free version of commercial PDF converter software. CutePDF Writer installs itself as a "printer subsystem". This enables virtually any Windows applications (must be able to print) to convert to professional quality PDF documents - with just a push of a button!
@@ -15,17 +15,17 @@ Portable Document Format (PDF) is the de facto standard for the secure and relia
 
 - Free software for commercial and non-commercial use.
     </description>
-    <projectUrl>http://www.cutepdf.com/</projectUrl>
+    <projectUrl>http://www.cutepdf.com/products/cutepdf/writer.asp</projectUrl>
     <tags>PDF Printer Converter Office freeware admin</tags>
-    <copyright></copyright>
+    <copyright>Copyright © Acro Software Inc.</copyright>
     <licenseUrl>http://www.cutepdf.com/Info/legal.asp</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/e4a49519947c3cff55c17a0b08266c56b0613e64/icons/cutepdf.png</iconUrl>
-    <dependencies>
-      <dependency id="Ghostscript.app" version="8.15" />
-    </dependencies>
-    <releaseNotes>http://www.cutepdf.com/support/updates.asp</releaseNotes>
+    <releaseNotes>[Software Updates](http://www.cutepdf.com/Support/updates.asp)</releaseNotes>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/cutepdf</packageSourceUrl>
+    <dependencies>
+      <dependency id="ghostscript.app" version="8.15" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/cutepdf/cutepdf.nuspec
+++ b/automatic/cutepdf/cutepdf.nuspec
@@ -6,7 +6,7 @@
     <title>CutePDF Writer</title>
     <version>3.1</version>
     <authors>Acro Software Inc.</authors>
-    <owners>Redsandro Thilas</owners>
+    <owners>Redsandro,Thilas</owners>
     <summary>Free PDF printer driver with no watermarks.</summary>
     <description>
 Portable Document Format (PDF) is the de facto standard for the secure and reliable distribution and exchange of electronic documents and forms around the world.  CutePDF Writer is the free version of commercial PDF converter software. CutePDF Writer installs itself as a "printer subsystem". This enables virtually any Windows applications (must be able to print) to convert to professional quality PDF documents - with just a push of a button!

--- a/automatic/cutepdf/tools/chocolateyInstall.ps1
+++ b/automatic/cutepdf/tools/chocolateyInstall.ps1
@@ -9,6 +9,7 @@ $packageArgs = @{
   url           = $url
   silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-' # Inno Setup Package
   validExitCodes= @(0)
+  softwareName  = 'cutepdf*'
   checksum      = $checksum
   checksumType  = 'sha256'
 }

--- a/automatic/cutepdf/tools/chocolateyInstall.ps1
+++ b/automatic/cutepdf/tools/chocolateyInstall.ps1
@@ -1,16 +1,30 @@
+﻿$ErrorActionPreference = 'Stop'
+
 $checksum = '2D9E07F25358C9D2317BC639AFCDEDDB893D1FCFD43BB66FF372DBA11E169EE1'
 $url = 'http://www.cutepdf.com/download/CuteWriter.exe'
 
 $packageArgs = @{
   packageName   = 'cutepdf'
-  unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
   fileType      = 'exe'
   url           = $url
   silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-' # Inno Setup Package
   validExitCodes= @(0)
-  softwareName  = 'cutepdf*'
   checksum      = $checksum
   checksumType  = 'sha256'
+}
+
+# Make sure Print Spooler service is up and running
+try {
+  $serviceName = 'Spooler'
+  $spoolerService = Get-WmiObject -Class Win32_Service -Property StartMode,State -Filter "Name='$serviceName'"
+  if ($spoolerService -eq $null) { throw "Service $serviceName was not found" }
+  Write-Host "Print Spooler service state: $($spoolerService.StartMode) / $($spoolerService.State)"
+  if ($spoolerService.StartMode -ne 'Auto' -or $spoolerService.State -ne 'Running') {
+    Set-Service $serviceName -StartupType Automatic -Status Running
+    Write-Host 'Print Spooler service new state: Auto / Running'
+  }
+} catch {
+  Write-Warning "Unexpected error while checking Print Spooler service: $($_.Exception.Message)"
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Chocolatey verifier service environment happens to have this service disabled. That's why cutepdf was failing.

Otherwise, I found out that uninstall wasn't silent and cannot be right now without an AutoIt script (see http://superuser.com/questions/580555/cutepdf-writer-problems-with-silent-uninstall). I didn't change a thing on this side.