### PR TITLE
Adobe Flash Updates and PPAPI to AU status

### DIFF
--- a/automatic/flashplayeractivex/update.ps1
+++ b/automatic/flashplayeractivex/update.ps1
@@ -33,7 +33,7 @@ function global:au_GetLatest {
   $CurrentVersion = ( $try.Version )
   $majorVersion = ([version] $CurrentVersion).Major
 
-  $url32 = "https://fpdownload.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_plugin.msi"
+  $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_plugin.msi"
 
   return @{ URL32 = $url32; Version = $CurrentVersion; majorVersion = $majorVersion; }
 }

--- a/automatic/flashplayerppapi/flashplayerppapi.nuspec
+++ b/automatic/flashplayerppapi/flashplayerppapi.nuspec
@@ -2,9 +2,9 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>{{PackageName}}</id>
+    <id>flashplayerppapi</id>
     <title>Flash Player PPAPI</title>
-    <version>{{PackageVersion}}</version>
+    <version>24.0.0.194</version>
     <authors>Adobe Systems Incorporated</authors>
     <owners>chocolatey</owners>
     <summary>Adobe Flash Player PPAPI Plugin for Opera and Chromium based browsers</summary>

--- a/automatic/flashplayerppapi/flashplayerppapi.nuspec
+++ b/automatic/flashplayerppapi/flashplayerppapi.nuspec
@@ -12,8 +12,9 @@
     <projectUrl>https://www.adobe.com/software/flash/about/</projectUrl>
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/e4a49519947c3cff55c17a0b08266c56b0613e64/icons/flashplayer.png</iconUrl>
     <tags>adobe flash player ppapi plugin admin</tags>
-    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
+    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/flashplayerppapi</packageSourceUrl>
     <licenseUrl>https://www.adobe.com/products/clients/all_dist_agreement.html</licenseUrl>
+    <releaseNotesUrl>https://helpx.adobe.com/flash-player/flash-player-releasenotes.html</releaseNotesUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
   <files>

--- a/automatic/flashplayerppapi/tools/ChocolateyInstall.ps1
+++ b/automatic/flashplayerppapi/tools/ChocolateyInstall.ps1
@@ -1,6 +1,4 @@
 $packageName = 'flashplayerppapi'
-$version = '24.0.0.194'
-$majorVersion = '24'
 
 $packageArgs = @{
   packageName   = $packageName

--- a/automatic/flashplayerppapi/tools/ChocolateyInstall.ps1
+++ b/automatic/flashplayerppapi/tools/ChocolateyInstall.ps1
@@ -1,9 +1,16 @@
-﻿$packageName = '{{PackageName}}'
-$version = '{{PackageVersion}}'
-$installerType = 'exe'
-$url = '{{DownloadUrl}}'
-$silentArgs = '-install'
-$validExitCodes = @(0)
+$packageName = 'flashplayerppapi'
+$version = '24.0.0.194'
+$majorVersion = '24'
+
+$packageArgs = @{
+  packageName   = $packageName
+  fileType      = 'msi'
+  url           = 'https://download.macromedia.com/pub/flashplayer/pdc/24.0.0.194/install_flash_player_24_ppapi.msi'
+  silentArgs    = '/quiet /norestart REMOVE_PREVIOUS=YES'
+  softwareName  = 'Flash Player PPAPI'
+  checksum      = 'EA84BE85075FC05E34CB4FCB2F214276C1066AE534835840F1D2F68CA2104410'
+  checksumType  = 'sha256'
+}
 
 #installer automatically overrides existing PPAPI installation
-Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url"  -validExitCodes $validExitCodes
+Install-ChocolateyPackage @packageArgs

--- a/automatic/flashplayerppapi/update.ps1
+++ b/automatic/flashplayerppapi/update.ps1
@@ -13,8 +13,6 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
-      "(^[$]version\s*=\s*)('.*')"= "`$1'$($Latest.Version)'"
-      "(^[$]majorVersion\s*=\s*)('.*')"= "`$1'$($Latest.majorVersion)'"
       "(^[$]packageName\s*=\s*)('.*')"= "`$1'$($Latest.PackageName)'"
       "(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
       "(?i)(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
@@ -35,7 +33,7 @@ function global:au_GetLatest {
 
   $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_ppapi.msi"
 
-  return @{ URL32 = $url32; Version = $CurrentVersion; majorVersion = $majorVersion; }
+  return @{ URL32 = $url32 }
 }
 
 update -ChecksumFor 32

--- a/automatic/flashplayerppapi/update.ps1
+++ b/automatic/flashplayerppapi/update.ps1
@@ -1,0 +1,41 @@
+
+import-module au
+
+$releases = "https://get.adobe.com/en/flashplayer/" # URL to for GetLatest
+
+function global:au_BeforeUpdate {
+  # We need this, otherwise the checksum won't get created
+  # Since windows 8 or later is skipped.
+  $Latest.ChecksumType32 = 'sha256'
+  $Latest.Checksum32     = Get-RemoteChecksum $Latest.URL32
+}
+
+function global:au_SearchReplace {
+  @{
+    ".\tools\chocolateyInstall.ps1" = @{
+      "(^[$]version\s*=\s*)('.*')"= "`$1'$($Latest.Version)'"
+      "(^[$]majorVersion\s*=\s*)('.*')"= "`$1'$($Latest.majorVersion)'"
+      "(^[$]packageName\s*=\s*)('.*')"= "`$1'$($Latest.PackageName)'"
+      "(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
+      "(?i)(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+      "(?i)(^\s*checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
+    }
+  }
+}
+
+function global:au_GetLatest {
+
+  $HTML = Invoke-WebRequest -Uri $releases
+  $try = ($HTML.ParsedHtml.getElementsByTagName('p') | Where{ $_.className -eq 'NoBottomMargin' } ).innerText
+  $try = $try  -split "\r?\n"
+  $try = $try[0] -replace ' ', ' = '
+  $try =  ConvertFrom-StringData -StringData $try
+  $CurrentVersion = ( $try.Version )
+  $majorVersion = ([version] $CurrentVersion).Major
+
+  $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_ppapi.msi"
+
+  return @{ URL32 = $url32; Version = $CurrentVersion; majorVersion = $majorVersion; }
+}
+
+update -ChecksumFor 32


### PR DESCRIPTION
@gep13 @AdmiringWorm 
This is just a small update to the Flash ActiveX  URL. The one that @AdmiringWorm changed it to is one of the round robin servers.

The rest is updating the Flash PPAPI package to use AU.

Also is it possible to make the updates to the Flash ActiveX & PPAPI be a incremental package update so that the new URL gets pushed to the public feed 😄. Right now they are both giving 404 errors 