### PR TITLE
(git*) Fix issues with Git packages

### DIFF
--- a/automatic/git.install/git.install.nuspec
+++ b/automatic/git.install/git.install.nuspec
@@ -47,6 +47,7 @@ The package uses default install options minus cheetah integration and desktop i
   </metadata>
   <files>
     <file src="tools\**" target="tools" />
+    <file src="legal\**" target="legal" />
   </files>
 </package>
 <!-- character encoding: “UTF-8” -->

--- a/automatic/git.portable/git.portable.nuspec
+++ b/automatic/git.portable/git.portable.nuspec
@@ -32,6 +32,7 @@ Git for Windows focuses on offering a lightweight, native set of tools that brin
   </metadata>
   <files>
     <file src="tools\**" target="tools" />
+    <file src="legal\**" target="legal" />
   </files>
 </package>
 <!-- character encoding: “UTF-8” -->

--- a/automatic/git.portable/tools/chocolateyInstall.ps1
+++ b/automatic/git.portable/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$filePath32 = "$toolsPath\PortableGit-2.11.0-32-bit.7z.exe"
-$filePath64 = "$toolsPath\PortableGit-2.11.0-64-bit.7z.exe"
+$filePath32 = "$toolsPath\PortableGit-2.11.0.2-32-bit.7z.exe"
+$filePath64 = "$toolsPath\PortableGit-2.11.0.2-64-bit.7z.exe"
 
 $filePath = if ((Get-ProcessorBits 64) -and $env:chocolateyForceX86 -ne 'true') {
   Write-Host "Installing 64 bit version"

--- a/automatic/git.portable/update.ps1
+++ b/automatic/git.portable/update.ps1
@@ -26,6 +26,10 @@ function global:au_BeforeUpdate {
 
 function global:au_SearchReplace {
     @{
+        ".\tools\chocolateyInstall.ps1" = @{
+            "(^[$]filePath32\s*=\s*`"[$]toolsPath\\)(.*)`"" = "`$1$($Latest.FileName32)`""
+            "(^[$]filePath64\s*=\s*`"[$]toolsPath\\)(.*)`"" = "`$1$($Latest.FileName64)`""
+        }
         ".\legal\verification.txt" = @{
             "(?i)(32-Bit.+)\<.*\>" = "`${1}<$($Latest.URL32)>"
             "(?i)(64-Bit.+)\<.*\>" = "`${1}<$($Latest.URL64)>"

--- a/automatic/git/git.nuspec
+++ b/automatic/git/git.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>git</id>
@@ -6,7 +6,7 @@
     <version>2.11.0.2</version>
     <authors>The Git Development Community</authors>
     <owners>chocolatey</owners>
-    <summary>Git (for Windows) â€“ We bring the awesome Git SCM to Windows</summary>
+    <summary>Git (for Windows) – We bring the awesome Git SCM to Windows</summary>
     <description>
 Git for Windows focuses on offering a lightweight, native set of tools that bring the full feature set of the Git SCM to Windows while providing appropriate user interfaces for experienced Git users and novices alike.
 
@@ -46,4 +46,4 @@ The package uses default install options minus cheetah integration and desktop i
   <files>
   </files>    
 </package>
-<!-- character encoding: â€œUTF-8â€ -->
+<!-- character encoding: “UTF-8” -->


### PR DESCRIPTION
* (git.portable) Update filenames in chocolateyInstall.ps1
* (git.portabe) Add legal files to package
* (git) Remove BOM from .nuspec file
* (git.install) Add legal files to package

There's another issue with `git.install` during AU run: `Choco pack failed with exit code 1`
It works for me locally, is there a way to see the log and detailed error from the AU run somewhere?

Fixes #519