### PR TITLE
(git.install) Update git.install after changes were pushed

### DIFF
--- a/automatic/git.install/git.install.nuspec
+++ b/automatic/git.install/git.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>git.install</id>
     <title>Git (Install)</title>
-    <version>2.11.0</version>
+    <version>2.11.0.2</version>
     <authors>The Git Development Community</authors>
     <owners>chocolatey</owners>
     <summary>Git (for Windows) – We bring the awesome Git SCM to Windows</summary>

--- a/automatic/git.install/legal/VERIFICATION.txt
+++ b/automatic/git.install/legal/VERIFICATION.txt
@@ -5,14 +5,14 @@ in verifying that this package's contents are trustworthy.
 The installer have been downloaded from GitHub and can be verified like this:
 
 1. Download the following installers:
-  32-Bit: <https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-32-bit.exe>
-  64-Bit: <https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-64-bit.exe>
+  32-Bit: <https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.2/Git-2.11.0.2-32-bit.exe>
+  64-Bit: <https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.2/Git-2.11.0.2-64-bit.exe>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum32: 2A6083479538C4FE454336660FCE96346EE3CF46F99CE08A666D4635539239D7
-  checksum64: FD1937EA8468461D35D9CABFCDD2DAA3A74509DC9213C43C2B9615E8F0B85086
+  checksum32: F7862331C994072402F9D7F03A4A6E2CAEC8CE0E91581FFBC6114631E920D9C9
+  checksum64: C7C6F8BA88A6DA491117E03DF559ABD0FECE1352F40D8B2D9BFFC9C6C12C5800
 
 File 'LICENSE.txt' is obtained from <https://github.com/git-for-windows/git/blob/703601d6780c32d33dadf19b2b367f2f79e1e34c/COPYING>

--- a/automatic/git.install/tools/chocolateyInstall.ps1
+++ b/automatic/git.install/tools/chocolateyInstall.ps1
@@ -3,8 +3,8 @@ $ErrorActionPreference = 'Stop'
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 . $toolsPath\helpers.ps1
 
-$filePath32 = "$toolsPath\Git-2.11.0-32-bit.exe"
-$filePath64 = "$toolsPath\Git-2.11.0-64-bit.exe"
+$filePath32 = "$toolsPath\Git-2.11.0.2-32-bit.exe"
+$filePath64 = "$toolsPath\Git-2.11.0.2-64-bit.exe"
 
 $fileArgs = "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/NOCANCEL", "/SP-", "/LOG"
 $components = "icons", "icons\quicklaunch", "ext", "ext\shellhere", "ext\guihere", "assoc", "assoc_sh"


### PR DESCRIPTION
Update git.install after changes were pushed to chocolatey.org by AU but not commited to repository.

Or is there another way to have the files updated after a failing run?