### PR TITLE
(git.install) Revert registry detection logic back as it originally was

### DIFF
--- a/automatic/git.install/tools/helpers.ps1
+++ b/automatic/git.install/tools/helpers.ps1
@@ -1,8 +1,8 @@
 function Get-InstallKey() {
     $registryKeyName = 'Git_is1'
-    $installKey = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$registryKeyName"
-    if ((Get-ProcessorBits 64) -and $env:chocolateyForceX86 -ne 'true') {
-        $installKey = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$registryKeyName"
+    $installKey = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$registryKeyName"
+    if ((Get-ProcessorBits 64) -and $env:chocolateyForceX86 -eq 'true') {
+        $installKey = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$registryKeyName"
     }
 
     $userInstallKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$registryKeyName"


### PR DESCRIPTION
Revert logic of registry key detection back as it was before migration to core team repo and refactorings

Fixes #524