### PR TITLE
(iTunes) Update to latest version and fix install errors

### DIFF
--- a/automatic/iTunes/tools/chocolateyInstall.ps1
+++ b/automatic/iTunes/tools/chocolateyInstall.ps1
@@ -14,12 +14,12 @@ $packageArgs = @{
   checksumType64 = 'sha256'
   silentArgs     = "/qn /norestart"
   validExitCodes = @(0, 2010, 1641)
-  unzipLocation = Get-PackageCacheLocation
+  unzipLocation  = Get-PackageCacheLocation
 }
 
 $app = Get-UninstallRegistryKey -SoftwareName $packageArgs.softwareName | select -first 1
 
-if ($app -and ([version]$app.Version -ge [version]$version)) {
+if ($app -and ([version]$app.DisplayVersion -ge [version]$version) -and ($env:ChocolateyForce -ne $true)) {
   Write-Host "iTunes $version or higher is already installed."
   Write-Host "No need to download and install again"
   return;
@@ -37,4 +37,4 @@ foreach ($msiFile in $msiFileList) {
   Install-ChocolateyInstallPackage @packageArgs
 }
 
-Remove-Item $packageArgs.unzipLocation -Recurse
+Remove-Item $packageArgs.unzipLocation -Recurse -Force -ea 0

--- a/automatic/iTunes/update.ps1
+++ b/automatic/iTunes/update.ps1
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 ﻿Import-Module AU
+=======
+Import-Module AU
+>>>>>>> (itunes) Added AU update script
 
 $releases     = 'https://www.apple.com/itunes/download/'
 $softwareName = 'iTunes'

--- a/automatic/iTunes/update.ps1
+++ b/automatic/iTunes/update.ps1
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 ﻿Import-Module AU
-=======
-Import-Module AU
->>>>>>> (itunes) Added AU update script
 
 $releases     = 'https://www.apple.com/itunes/download/'
 $softwareName = 'iTunes'


### PR DESCRIPTION
This fixes the invalid cast exception from Object[] to Version[], adds a link to the 32 bit version and points both 32 and 64 bit to the latest version