### PR TITLE
(mkdocs-material) Update min mkdocs version to 0.16.0

### DIFF
--- a/automatic/mkdocs-material/mkdocs-material.nuspec
+++ b/automatic/mkdocs-material/mkdocs-material.nuspec
@@ -30,7 +30,7 @@ Material is a theme for [MkDocs](http://www.mkdocs.org/), an excellent static si
     <tags>mkdocs markdown documentation material foss cross-platform cli</tags>
     <releaseNotes>https://github.com/squidfunk/mkdocs-material/blob/master/CHANGELOG</releaseNotes>
     <dependencies>
-      <dependency id="MkDocs" version="0.15.0" />
+      <dependency id="MkDocs" version="0.16.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Update dependency to mkdocs since 1.0.0 mkdocs-material requires mkdocs 0.16.0

As per [this comment](http://disq.us/p/1f8z4b3)