### PR TITLE
flashplayeractivex : replace outdated download url with the new one

### DIFF
--- a/automatic/flashplayeractivex/tools/chocolateyInstall.ps1
+++ b/automatic/flashplayeractivex/tools/chocolateyInstall.ps1
@@ -29,10 +29,10 @@ if ($allRight) {
 $packageArgs = @{
   packageName   = $packageName
   fileType      = 'msi'
-  url           = 'https://download.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_24_active_x.msi'
+  url           = 'https://fpdownload.macromedia.com/pub/flashplayer/pdc/24.0.0.194/install_flash_player_24_plugin.msi'
   silentArgs    = '/quiet /norestart REMOVE_PREVIOUS=YES'
   softwareName  = 'Adobe Flash Player ActiveX'
-  checksum      = 'd1d60df68b172f2cb21e4f8572bbb6727385bf4e5874df95560947d35956bb9d'
+  checksum      = '81d5c96efe58e6ddaaa296da282688eb656ade966fa97671c87b1a89427f1583'
   checksumType  = 'sha256'
 }
   Install-ChocolateyPackage @packageArgs

--- a/automatic/flashplayeractivex/update.ps1
+++ b/automatic/flashplayeractivex/update.ps1
@@ -33,9 +33,10 @@ function global:au_GetLatest {
   $CurrentVersion = ( $try.Version )
   $majorVersion = ([version] $CurrentVersion).Major
 
-  $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_plugin.msi"
+  $url32 = "https://fpdownload.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_plugin.msi"
 
   return @{ URL32 = $url32; Version = $CurrentVersion; majorVersion = $majorVersion; }
 }
 
+#update -ChecksumFor 32 -NoCheckChocoVersion $true
 update -ChecksumFor 32


### PR DESCRIPTION
The base url used to download the flashplayer has changed from :
_https://download.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/_
to
_https://fpdownload.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/_