### PR TITLE
(build) Pad version script

### DIFF
--- a/automatic/flashplayeractivex/update.ps1
+++ b/automatic/flashplayeractivex/update.ps1
@@ -1,7 +1,9 @@
-
+﻿
 import-module au
+. "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
 $releases = "https://get.adobe.com/en/flashplayer/" # URL to for GetLatest
+$padVersionUnder = '24.0.1'
 
 function global:au_BeforeUpdate {
   # We need this, otherwise the checksum won't get created
@@ -13,7 +15,7 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
-      "(^[$]version\s*=\s*)('.*')"= "`$1'$($Latest.Version)'"
+      "(^[$]version\s*=\s*)('.*')"= "`$1'$($Latest.RemoteVersion)'"
       "(^[$]majorVersion\s*=\s*)('.*')"= "`$1'$($Latest.majorVersion)'"
       "(^[$]packageName\s*=\s*)('.*')"= "`$1'$($Latest.PackageName)'"
       "(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
@@ -35,7 +37,9 @@ function global:au_GetLatest {
 
   $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_plugin.msi"
 
-  return @{ URL32 = $url32; Version = $CurrentVersion; majorVersion = $majorVersion; }
+  $packageVersion = Get-Padded-Version $CurrentVersion $padVersionUnder
+
+  return @{ URL32 = $url32; Version = $packageVersion; RemoteVersion = $CurrentVersion; majorVersion = $majorVersion; }
 }
 
-update -ChecksumFor 32
+update -ChecksumFor none

--- a/automatic/flashplayerplugin/update.ps1
+++ b/automatic/flashplayerplugin/update.ps1
@@ -1,6 +1,8 @@
-import-module au
+﻿import-module au
+. "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
 $releases = 'https://get.adobe.com/flashplayer/'
+$padVersionUnder = '24.0.1'
 
 function global:au_SearchReplace {
    @{
@@ -22,7 +24,7 @@ function global:au_GetLatest {
   $version = ( $try.Version )
   $major_version = ([version]$version).Major
     @{
-        Version = $version
+        Version = Get-Padded-Version $version $padVersionUnder
         URL32   = "https://download.macromedia.com/get/flashplayer/pdc/${version}/install_flash_player_${major_version}_plugin.msi"
     }
 }

--- a/automatic/flashplayerppapi/flashplayerppapi.nuspec
+++ b/automatic/flashplayerppapi/flashplayerppapi.nuspec
@@ -14,7 +14,7 @@
     <tags>adobe flash player ppapi plugin admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/flashplayerppapi</packageSourceUrl>
     <licenseUrl>https://www.adobe.com/products/clients/all_dist_agreement.html</licenseUrl>
-    <releaseNotesUrl>https://helpx.adobe.com/flash-player/flash-player-releasenotes.html</releaseNotesUrl>
+    <releaseNotes>https://helpx.adobe.com/flash-player/flash-player-releasenotes.html</releaseNotes>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
   <files>

--- a/automatic/flashplayerppapi/update.ps1
+++ b/automatic/flashplayerppapi/update.ps1
@@ -1,7 +1,8 @@
-
-import-module au
+﻿import-module au
+. "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
 $releases = "https://get.adobe.com/en/flashplayer/" # URL to for GetLatest
+$padVersionUnder = '24.0.1'
 
 function global:au_BeforeUpdate {
   # We need this, otherwise the checksum won't get created
@@ -33,9 +34,9 @@ function global:au_GetLatest {
 
   $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${currentVersion}/install_flash_player_${majorVersion}_ppapi.msi"
 
-  return @{ 
-    URL32 = $url32 
-    Version = $currentVersion
+  return @{
+    URL32 = $url32
+    Version = Get-Padded-Version $currentVersion $padVersionUnder
   }
 }
 

--- a/scripts/Get-Padded-Version.ps1
+++ b/scripts/Get-Padded-Version.ps1
@@ -1,9 +1,47 @@
+<#
+.SYNOPSIS
+  Pad the revision number if the passed version is using a 4-part version scheme.
+
+.DESCRIPTION
+  Adds padded zeroes to the revision part of the version if the passed
+  Version parameter is using a 4-part scheme and the Parameter OnlyBelowVersion
+  is either $null or greater than the Version parameter.
+
+.PARAMETER Version
+  The version number to add the revision padding to (Pre-Releases is not supported).
+
+.PARAMETER OnlyBelowVersion
+  Only add padded zeroes to a Version when it is below this parameter, or always
+  add padded zeroes if this parameter is $null.
+
+.PARAMETER RevisionLength
+  The total length of the revision number part
+
+.OUTPUTS
+  The full padded version, or the specified Version if padding was not needed.
+
+.EXAMPLE
+  Get-Padded-Version -Version '24.0.0.195'
+  will output '24.0.0.195000' if the nuspec version is less than the version
+
+.EXAMPLE
+  Get-Padded-Version -Version '24.0.0.195'
+  will output '24.0.0.195001' if the nuspec version is equal to '24.0.0.195'
+  or equal to '24.0.0.195000'
+
+.EXAMPLE
+  Get-Padded-Version -Version '24.0.1.2' -OnlyBelowVersion '24.0.1'
+  Will output the same version that was given without padded zeroes.
+#>
+
 function Get-Padded-Version() {
   param(
     [Parameter(Mandatory = $true, Position = 0)]
     [string]$Version,
     [Parameter(Position = 1)]
-    [version]$OnlyBelowVersion = $null
+    [version]$OnlyBelowVersion = $null,
+    [Parameter(Position = 2)]
+    [int]$RevisionLength = 6
   )
 
   if ($Version -match "^([\d]+\.){1,2}[\d]+$") {
@@ -22,7 +60,7 @@ function Get-Padded-Version() {
 
   $versionInfo = [version]$Version
   $revision = $versionInfo.Revision
-  $paddedRev = [int]($revision.ToString().PadRight(6, '0'));
+  $paddedRev = [int]($revision.ToString().PadRight($RevisionLength, '0'));
 
   if ($global:au_force -eq $true) {
     Write-Debug "Loading nuspec file to see if we need to pad the version"
@@ -30,7 +68,7 @@ function Get-Padded-Version() {
     $content | ? { $_ -match "\<version\>([\d\.]+)\<\/version\>" } | Out-Null
     if ($Matches) {
       $newVersion = [version]$Matches[1]
-      $paddedNewRev = [int]$newVersion.Revision.ToString().PadRight(6, '0')
+      $paddedNewRev = [int]$newVersion.Revision.ToString().PadRight($RevisionLength, '0')
       while ($paddedRev -le $paddedNewRev) {
         $paddedRev++ | Out-Null
       }

--- a/scripts/Get-Padded-Version.ps1
+++ b/scripts/Get-Padded-Version.ps1
@@ -3,7 +3,7 @@ function Get-Padded-Version() {
     [Parameter(Mandatory = $true, Position = 0)]
     [string]$Version,
     [Parameter(Position = 1)]
-    [version]$MaximumVersion = $null
+    [version]$OnlyBelowVersion = $null
   )
 
   if ($Version -match "^([\d]+\.){1,2}[\d]+$") {
@@ -16,7 +16,7 @@ function Get-Padded-Version() {
 
   $Matches = $null
 
-  if ($MaximumVersion -ne $null -and ([version]$Version) -ge $MaximumVersion) {
+  if ($OnlyBelowVersion -ne $null -and ([version]$Version) -ge $OnlyBelowVersion) {
     return $Version;
   }
 

--- a/scripts/Get-Padded-Version.ps1
+++ b/scripts/Get-Padded-Version.ps1
@@ -1,0 +1,41 @@
+function Get-Padded-Version() {
+  param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Version,
+    [Parameter(Position = 1)]
+    [version]$MaximumVersion = $null
+  )
+
+  if ($Version -match "^([\d]+\.){1,2}[\d]+$") {
+    Write-Debug "There is no need to pad the version information"
+    return $Version
+  } elseif ($Version -notmatch "^[\d\.]+$") {
+    Write-Warning "Padding of pre release versions is not supported";
+    return $Version
+  }
+
+  $Matches = $null
+
+  if ($MaximumVersion -ne $null -and ([version]$Version) -ge $MaximumVersion) {
+    return $Version;
+  }
+
+  $versionInfo = [version]$Version
+  $revision = $versionInfo.Revision
+  $paddedRev = [int]($revision.ToString().PadRight(6, '0'));
+
+  if ($global:au_force -eq $true) {
+    Write-Debug "Loading nuspec file to see if we need to pad the version"
+    $content = gc -Encoding UTF8 (Resolve-Path "*.nuspec");
+    $content | ? { $_ -match "\<version\>([\d\.]+)\<\/version\>" } | Out-Null
+    if ($Matches) {
+      $newVersion = [version]$Matches[1]
+      $paddedNewRev = [int]$newVersion.Revision.ToString().PadRight(6, '0')
+      while ($paddedRev -le $paddedNewRev) {
+        $paddedRev++ | Out-Null
+      }
+    }
+  }
+
+  return $versionInfo.ToString() -replace '^([\d]+\.[\d]+\.[\d]+\.)\d+$',"`${1}$paddedRev"
+}

--- a/scripts/Get-Padded-Version.ps1
+++ b/scripts/Get-Padded-Version.ps1
@@ -40,7 +40,6 @@ function Get-Padded-Version() {
     [string]$Version,
     [Parameter(Position = 1)]
     [version]$OnlyBelowVersion = $null,
-    [Parameter(Position = 2)]
     [int]$RevisionLength = 6
   )
 
@@ -55,6 +54,7 @@ function Get-Padded-Version() {
   $Matches = $null
 
   if ($OnlyBelowVersion -ne $null -and ([version]$Version) -ge $OnlyBelowVersion) {
+    Write-Debug "Version is greater than or equal to $OnlyBelowVersion, no need to pad revision version."
     return $Version;
   }
 


### PR DESCRIPTION
I've added a script to allow for easier access to padding the revision number of packages
which already uses 4-part version scheme.
The script also checks if the global variable 'au_force' is set to true and then increases the revision number based on what is shown as the latest in the corresponding nuspec file.

Also added to the flashplayer* packages to use those scripts (plans to add it to autoit packages as well).

I know I've not added any documentation of the script, and honestly didn't want to use time on it yet either.

/cc @pascalberger @gep13 @ferventcoder 