### PR TITLE
(git-disable-gcm) Add package for disabling Git Credential Manager

### DIFF
--- a/automatic/git.install/git.install.nuspec
+++ b/automatic/git.install/git.install.nuspec
@@ -32,7 +32,9 @@ For example: `-params '"/GitAndUnixToolsOnPath /NoAutoCrlf"'`.
 
 ## Notes
 
-- The package uses default install options minus cheetah integration and desktop icons. Cheetah prevents a good upgrade scenario, so it has been removed.
+The package uses default install options minus cheetah integration and desktop icons. Cheetah prevents a good upgrade scenario, so it has been removed.
+
+For disabling the Git Credential Manager see the [Disable Git Credential Manager package](https://chocolatey.org/packages/git-disable-gcm).
     </description>
     <projectUrl>https://git-for-windows.github.io/</projectUrl>
     <projectSourceUrl>https://github.com/git-for-windows/git</projectSourceUrl>

--- a/automatic/git/git.nuspec
+++ b/automatic/git/git.nuspec
@@ -32,7 +32,9 @@ For example: `-params '"/GitAndUnixToolsOnPath /NoAutoCrlf"'`.
 
 ## Notes
 
-- The package uses default install options minus cheetah integration and desktop icons. Cheetah prevents a good upgrade scenario, so it has been removed.
+The package uses default install options minus cheetah integration and desktop icons. Cheetah prevents a good upgrade scenario, so it has been removed.
+
+For disabling the Git Credential Manager see the [Disable Git Credential Manager package](https://chocolatey.org/packages/git-disable-gcm).
 </description>
     <projectUrl>https://git-for-windows.github.io/</projectUrl>
     <projectSourceUrl>https://github.com/git-for-windows/git</projectSourceUrl>

--- a/manual/git-disable-gcm/git-disable-gcm.nuspec
+++ b/manual/git-disable-gcm/git-disable-gcm.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>git-disable-gcm</id>
+    <title>Disable Git Credential Manager</title>
+    <version>1.0.0</version>
+    <authors>chocolatey</authors>
+    <owners>chocolatey, Pascal Berger</owners>
+    <projectSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/manual/git-disable-gcm</projectSourceUrl>
+    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/manual/git-disable-gcm</packageSourceUrl>
+    <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/10a8d98b2f320b565fa5349a4352e79666db71ff/icons/git.svg</iconUrl>
+    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>Disable Git Credential Manager</summary>
+    <description>Disables the Git Credential Manager which is installed as part of the [Git](https://chocolatey.org/packages/git.install/) package.</description>
+    <tags>git gcm admin foss cross-platform</tags>
+    <dependencies>
+      <dependency id="git" version="2.7.3" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/manual/git-disable-gcm/tools/chocolateyInstall.ps1
+++ b/manual/git-disable-gcm/tools/chocolateyInstall.ps1
@@ -1,0 +1,5 @@
+﻿$ErrorActionPreference = 'Stop'
+
+Update-SessionEnvironment
+
+git config --system --unset credential.helper

--- a/manual/git-disable-gcm/tools/chocolateyInstall.ps1
+++ b/manual/git-disable-gcm/tools/chocolateyInstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-Update-SessionEnvironment
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+. $toolsPath\helpers.ps1
 
-git config --system --unset credential.helper
+$gitExecutable = Get-GitExecutable
+& $gitExecutable config --system --unset credential.helper

--- a/manual/git-disable-gcm/tools/chocolateyUninstall.ps1
+++ b/manual/git-disable-gcm/tools/chocolateyUninstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-Update-SessionEnvironment
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+. $toolsPath\helpers.ps1
 
-git config --system credential.helper manager
+$gitExecutable = Get-GitExecutable
+& $gitExecutable config --system credential.helper manager

--- a/manual/git-disable-gcm/tools/chocolateyUninstall.ps1
+++ b/manual/git-disable-gcm/tools/chocolateyUninstall.ps1
@@ -1,0 +1,5 @@
+﻿$ErrorActionPreference = 'Stop'
+
+Update-SessionEnvironment
+
+git config --system credential.helper manager

--- a/manual/git-disable-gcm/tools/helpers.ps1
+++ b/manual/git-disable-gcm/tools/helpers.ps1
@@ -1,0 +1,23 @@
+﻿function Get-GitExecutable()
+{
+  $gitRegistryPath = $(
+    'HKLM:\SOFTWARE\GitForWindows'
+  )
+
+  if (Test-Path $gitRegistryPath) {
+    # Use Git executable based on registry entry for Git For Windows.
+    $gitInstallPath = (
+      Get-ItemProperty -Path $gitRegistryPath 
+    ).InstallPath
+    $gitExecutable = Join-Path(Join-Path $gitInstallPath "bin") "git.exe"
+  }
+  else {
+    # If no entry for Git was found in the registry, try to find git executable on the path.
+    Update-SessionEnvironment
+
+    $gitExecutable = "git"
+  }
+
+  Write-Host "Using Git from '$gitExecutable'"
+  return $gitExecutable
+}


### PR DESCRIPTION
Since the Git installer doesn't provide an option for not installing the GCM, I created a separate package which would disable GCM.

Disabling GCM while installing Git was originally requested in https://github.com/ferventcoder/chocolatey-packages/issues/149.