### PR TITLE
Allow numbers in flag names

### DIFF
--- a/extensions/chocolatey-core.extension/CHANGELOG.md
+++ b/extensions/chocolatey-core.extension/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
+## 1.0.7
+- Bugfix in `Get-PackageParameters`: flags can now have numbers in their names, whereas before, everything past the number would be truncated and the flag would turn into a boolean.
+
 ## 1.0.6
-- Bufix in `Get-AppInstallLocation`: Powershell 2 can not replace on null value.
+- Bugfix in `Get-AppInstallLocation`: Powershell 2 can not replace on null value.
 
 ## 1.0.5
 

--- a/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
+++ b/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chocolatey-core.extension</id>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <title>Chocolatey Core Extensions</title>
     <summary>Helper functions extending core choco functionality</summary>
     <authors>chocolatey</authors>

--- a/extensions/chocolatey-core.extension/extensions/Get-PackageParameters.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-PackageParameters.ps1
@@ -12,7 +12,6 @@
 #>
 function Get-PackageParameters([string] $Parameters = $Env:ChocolateyPackageParameters) {
     $res = @{}
-    write-host "p:  $Parameters"
 
     $re = "\/([a-zA-Z0-9]+)(:([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)?"
     $results = $Parameters | Select-String $re -AllMatches | select -Expand Matches
@@ -24,6 +23,5 @@ function Get-PackageParameters([string] $Parameters = $Env:ChocolateyPackagePara
         if ($val -match '^(".+")|(''.+'')$') {$val = $val -replace '^.|.$'}
         $res[ $opt ] = if ($val) { $val } else { $true }
     }
-    write-host $res
     $res
 }

--- a/extensions/chocolatey-core.extension/extensions/Get-PackageParameters.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-PackageParameters.ps1
@@ -12,7 +12,9 @@
 #>
 function Get-PackageParameters([string] $Parameters = $Env:ChocolateyPackageParameters) {
     $res = @{}
-    $re = "\/([a-zA-Z]+)(:([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)?"
+    write-host "p:  $Parameters"
+
+    $re = "\/([a-zA-Z0-9]+)(:([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)?"
     $results = $Parameters | Select-String $re -AllMatches | select -Expand Matches
     foreach ($m in $results) {
         if (!$m) { continue } # must because of posh 2.0 bug: https://github.com/chocolatey/chocolatey-coreteampackages/issues/465
@@ -22,5 +24,6 @@ function Get-PackageParameters([string] $Parameters = $Env:ChocolateyPackagePara
         if ($val -match '^(".+")|(''.+'')$') {$val = $val -replace '^.|.$'}
         $res[ $opt ] = if ($val) { $val } else { $true }
     }
+    write-host $res
     $res
 }


### PR DESCRIPTION
Tested locally:
```
C:\src\github\chocolatey\chocolatey-coreteampackages\extensions\chocolatey-core.extension\extensions [fix_get_pp +0 ~1 -0 !]
λ  import-module .\chocolatey-core.psm1
C:\src\github\chocolatey\chocolatey-coreteampackages\extensions\chocolatey-core.extension\extensions [fix_get_pp +0 ~1 -0 !]
λ  get-packageparameters -Parameters "/foo:bar"
p:  /foo:bar
System.Collections.DictionaryEntry

Name                           Value
----                           -----
foo                            bar


C:\src\github\chocolatey\chocolatey-coreteampackages\extensions\chocolatey-core.extension\extensions [fix_get_pp +0 ~1 -0 !]
λ  get-packageparameters -Parameters "/foo2:bar"
p:  /foo2:bar
System.Collections.DictionaryEntry

Name                           Value
----                           -----
foo2                           bar
```