### PR TITLE
(chocolatey-core.extension) New Helper 'Get-AvailableDriveLetter'

### DIFF
--- a/extensions/chocolatey-core.extension/CHANGELOG.md
+++ b/extensions/chocolatey-core.extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.1.0
+- `Get-AvailableDriveLetter` - Get the next unused drive letter
+
 ## 1.0.7
 - Bugfix in `Get-PackageParameters`: flags can now have numbers in their names, whereas before, everything past the number would be truncated and the flag would turn into a boolean.
 

--- a/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
+++ b/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chocolatey-core.extension</id>
-    <version>1.0.7</version>
+    <version>1.1.0</version>
     <title>Chocolatey Core Extensions</title>
     <summary>Helper functions extending core choco functionality</summary>
     <authors>chocolatey</authors>

--- a/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
@@ -22,7 +22,7 @@
   http://stackoverflow.com/questions/12488030/getting-a-free-drive-letter/29373301#29373301
 #>
 function Get-AvailableDriveLetter {
-  param ([char[]]$ExcludedLetter)
+  param ([char[]]$ExcludedLetters)
 
   $Letter = [int][char]'C'
   $i = @()
@@ -31,11 +31,11 @@ function Get-AvailableDriveLetter {
   $(Get-PSDrive -PSProvider filesystem) | %{$i += $_.name}
   
   #Adding the excluded letter
-  $i+=$ExcludedLetter
+  $i+=$ExcludedLetters
   
   while($i -contains $([char]$Letter)){$Letter++}
 
-  if ($Letter -gt [int][char]'Z') {
+  if ($Letter -gt [char]'Z') {
     throw "error: no drive letter available!"
   }
   Write-Verbose "available drive letter: '$([char]$Letter)'"

--- a/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
@@ -13,7 +13,7 @@
   (do not return X, even if it'd be the next choice)
 
 .INPUTS
-  specific drive letter 
+  specific drive letter(s) that will be excluded as potential candidates
 
 .OUTPUTS
   System.String (single drive-letter character)
@@ -22,7 +22,7 @@
   http://stackoverflow.com/questions/12488030/getting-a-free-drive-letter/29373301#29373301
 #>
 function Get-AvailableDriveLetter {
-  param ([char]$ExcludedLetter)
+  param ([char[]]$ExcludedLetter)
 
   $Letter = [int][char]'C'
   $i = @()
@@ -35,6 +35,10 @@ function Get-AvailableDriveLetter {
   
   while($i -contains $([char]$Letter)){$Letter++}
 
+  if ($Letter -gt [int][char]'Z') {
+    throw "error: no drive letter available!"
+  }
+  Write-Verbose "available drive letter: '$([char]$Letter)'"
   Return $([char]$Letter)
 }
 

--- a/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
@@ -1,0 +1,40 @@
+﻿<#
+.SYNOPSIS
+  Get a 'free' drive letter
+
+.DESCRIPTION
+  Get a not yet in-use drive letter that can be used for mounting
+
+.EXAMPLE
+  Get-AvailableDriveLetter
+
+.EXAMPLE
+  Get-AvailableDriveLetter 'X'
+  (do not return X, even if it'd be the next choice)
+
+.INPUTS
+  specific drive letter 
+
+.OUTPUTS
+  System.String (single drive-letter character)
+
+.LINK
+  http://stackoverflow.com/questions/12488030/getting-a-free-drive-letter/29373301#29373301
+#>
+function Get-AvailableDriveLetter {
+  param ([char]$ExcludedLetter)
+
+  $Letter = [int][char]'C'
+  $i = @()
+  
+  #getting all the used Drive letters reported by the Operating System
+  $(Get-PSDrive -PSProvider filesystem) | %{$i += $_.name}
+  
+  #Adding the excluded letter
+  $i+=$ExcludedLetter
+  
+  while($i -contains $([char]$Letter)){$Letter++}
+
+  Return $([char]$Letter)
+}
+


### PR DESCRIPTION
should return the next free drive letter

very useful for mounting iso-files from cocolateyinstall.ps1