### PR TITLE
(googlechrome) Added revision padding

### DIFF
--- a/automatic/GoogleChrome/update.ps1
+++ b/automatic/GoogleChrome/update.ps1
@@ -1,6 +1,8 @@
 import-module au
+. "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
 $releases = 'http://omahaproxy.appspot.com/all?os=win&amp;channel=stable'
+$paddedUnderVersion = '56.0.2925'
 
 function global:au_SearchReplace {
    @{
@@ -15,10 +17,12 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
     $release_info = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    $version = $release_info | % Content | ConvertFrom-Csv | % current_version
+
     @{
         URL32 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'
         URL64 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
-        Version = $release_info | % Content | ConvertFrom-Csv | % current_version
+        Version = Get-Padded-Version -Version $version -OnlyBelowVersion $paddedUnderVersion -RevisionLength 5
     }
 }
 


### PR DESCRIPTION
This will add padding to the revision number whenever the version is less than `56.0.2925`

**IMPORTANT merge using `[AU googlechrome]`, otherwise the padding is applied but the revision number is not incremented (but still be pushed since `56.0.2925.87 != 56.0.2925.87000`**

fixes #604