### PR TITLE
(visualstudiocode-disableautoupdate) Update to latest Visual Studio Code version

### DIFF
--- a/manual/visualstudiocode-disableautoupdate/tools/chocolateyUninstall.ps1
+++ b/manual/visualstudiocode-disableautoupdate/tools/chocolateyUninstall.ps1
@@ -3,4 +3,4 @@
 $toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 . $toolsPath\helpers.ps1
 
-Set-UpdateChannel("stable")
+Set-UpdateChannel("default")

--- a/manual/visualstudiocode-disableautoupdate/tools/helpers.ps1
+++ b/manual/visualstudiocode-disableautoupdate/tools/helpers.ps1
@@ -4,7 +4,7 @@ function Set-UpdateChannel() {
     [string]$UpdateChannel
   )
 
-  $codeSettingsPath = $(Join-Path $env:APPDATA "Code") 
+  $codeSettingsPath = $(Join-Path $env:APPDATA -ChildPath "Code" | Join-Path -ChildPath "User") 
   if (-not (Test-Path $codeSettingsPath)) {
     Write-Output "Settings path '$codeSettingsPath' does not exist. Creating it now."
     New-Item -ItemType Directory -Path $codeSettingsPath | Out-Null
@@ -12,7 +12,7 @@ function Set-UpdateChannel() {
     Write-Output "Settings path '$codeSettingsPath' already exists."
   }
 
-  $storageFilePath = $(Join-Path $codeSettingsPath "storage.json")
+  $storageFilePath = $(Join-Path $codeSettingsPath "settings.json")
   if (-not (Test-Path $storageFilePath)) {
     Write-Output "Settings file '$storageFilePath' does not exist. Creating it now."
     New-Item -ItemType File -Path $storageFilePath | Out-Null
@@ -36,12 +36,12 @@ function Set-UpdateChannel() {
     try
     {
       $storageFileObject.updateChannel = "$UpdateChannel"
-      Write-Output "Updated 'updateChannel' to '$UpdateChannel'."
+      Write-Output "Updated 'update.channel' to '$UpdateChannel'."
     }
     catch
     {
-      Write-Output "Add new 'updateChannel' node with value '$UpdateChannel'."
-      $storageFileObject | Add-Member -Name "updateChannel" -value $UpdateChannel -MemberType NoteProperty
+      Write-Output "Add new 'update.channel' node with value '$UpdateChannel'."
+      $storageFileObject | Add-Member -Name "update.channel" -value $UpdateChannel -MemberType NoteProperty
     }
 
     if ($PSVersionTable.PSVersion.Major -gt 2) {

--- a/manual/visualstudiocode-disableautoupdate/visualstudiocode-disableautoupdate.nuspec
+++ b/manual/visualstudiocode-disableautoupdate/visualstudiocode-disableautoupdate.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>visualstudiocode-disableautoupdate</id>
     <title>Visual Studio Code Auto Update Deactivation</title>
-    <version>1.0.0</version>
+    <version>1.0.0.20170302</version>
     <authors>chocolatey</authors>
     <owners>chocolatey, Pascal Berger</owners>
     <projectUrl>https://github.com/chocolatey/chocolatey-coreteampackages</projectUrl>


### PR DESCRIPTION
Current version of Visual Studio Code no longer seems to support `storage.json` file. Setting is therefore written to `settings.json`. Also default channel is now called `default` instead of `stable`.

Needs to be merged with `[PUSH visualstudiocode-disableautoupdate]` in message