### PR TITLE
smartftp: add min os check

### DIFF
--- a/automatic/smartftp/tools/chocolateyInstall.ps1
+++ b/automatic/smartftp/tools/chocolateyInstall.ps1
@@ -1,5 +1,11 @@
 $ErrorActionPreference = 'Stop'
 
+if ([System.Environment]::OSVersion.Version -lt (new-object 'Version' 6, 3)) {
+  $errorMessage = 'Your Windows version is not suitable for this package. This package is only for Windows 8.1 or higher'
+  Write-Output $packageName $errorMessage
+  throw $errorMessage
+}
+
 $packageArgs = @{
   packageName            = 'smartftp'
   fileType               = 'msi'


### PR DESCRIPTION
The new version requires Windows 8.1 (version = 6.3) or higher.