### PR TITLE
smartftp: removed KB dependencies

### DIFF
--- a/automatic/smartftp/smartftp.nuspec
+++ b/automatic/smartftp/smartftp.nuspec
@@ -59,8 +59,6 @@ SmartFTP is a fast and reliable FTP, FTPS, SFTP, HTTP, Amazon S3, WebDAV, Google
     <bugTrackerUrl>https://www.smartftp.com/forums/index.php?/forum/14-support/</bugTrackerUrl>
     <dependencies>
       <dependency id="vcredist2017" version="14.10.25008.0" />
-      <dependency id="KB2533623" version="1.0.0" />
-      <dependency id="KB2670838" version="1.0.0" />
     </dependencies>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/smartftp</packageSourceUrl>
     <docsUrl>https://www.smartftp.com/support</docsUrl>


### PR DESCRIPTION
The package requires Windows 8.1 or higher which makes the dependencies on the Pre-Windows 8.1 KB updates obsolete.