### PR TITLE
(GH-621) PowerShell functions - allow for ignored parameters and splatting

### DIFF
--- a/extensions/chocolatey-core.extension/CHANGELOG.md
+++ b/extensions/chocolatey-core.extension/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Use `$IgnoredArguments` in all functions to allow for future expansion and splatting ([#621](https://github.com/chocolatey/chocolatey-coreteampackages/issues/621))
 
 ## 1.1.0
-- `Get-AvailableDriveLetter` - Get the next unused drive letter
+- `Get-AvailableDriveLetter`: Get the next unused drive letter
 
 ## 1.0.7
 - Bugfix in `Get-PackageParameters`: flags can now have numbers in their names, whereas before, everything past the number would be truncated and the flag would turn into a boolean.
@@ -44,4 +44,4 @@
 
 ## Version 0.1.3
 
-- `Get-WebContent` -  Download file with choco internals.
+- `Get-WebContent`:  Download file with choco internals.

--- a/extensions/chocolatey-core.extension/CHANGELOG.md
+++ b/extensions/chocolatey-core.extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.2.0
+
+- Use `$IgnoredArguments` in all functions to allow for future expansion and splatting ([#621](https://github.com/chocolatey/chocolatey-coreteampackages/issues/621))
+
 ## 1.1.0
 - `Get-AvailableDriveLetter` - Get the next unused drive letter
 

--- a/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
+++ b/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chocolatey-core.extension</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>Chocolatey Core Extensions</title>
     <summary>Helper functions extending core choco functionality</summary>
     <authors>chocolatey</authors>

--- a/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
@@ -25,7 +25,11 @@ function Get-AppInstallLocation {
     param(
         # Regular expression pattern
         [ValidateNotNullOrEmpty()]
-        [string] $AppNamePattern
+        [string] $AppNamePattern,
+
+        # Allows splatting with arguments that do not apply and future expansion. Do not use directly.
+        [parameter(ValueFromRemainingArguments = $true)]
+        [Object[]] $IgnoredArguments
     )
 
     function strip($path) { if ($path.EndsWith('\')) { return $path -replace '.$' } else { $path } }

--- a/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
@@ -32,13 +32,13 @@ function Get-AvailableDriveLetter {
 
   $Letter = [int][char]'C'
   $i = @()
-  
+
   #getting all the used Drive letters reported by the Operating System
   $(Get-PSDrive -PSProvider filesystem) | %{$i += $_.name}
-  
+
   #Adding the excluded letter
   $i+=$ExcludedLetters
-  
+
   while($i -contains $([char]$Letter)){$Letter++}
 
   if ($Letter -gt [char]'Z') {

--- a/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AvailableDriveLetter.ps1
@@ -22,7 +22,13 @@
   http://stackoverflow.com/questions/12488030/getting-a-free-drive-letter/29373301#29373301
 #>
 function Get-AvailableDriveLetter {
-  param ([char[]]$ExcludedLetters)
+  param (
+    [char[]]$ExcludedLetters,
+
+    # Allows splatting with arguments that do not apply and future expansion. Do not use directly.
+    [parameter(ValueFromRemainingArguments = $true)]
+    [Object[]] $IgnoredArguments
+  )
 
   $Letter = [int][char]'C'
   $i = @()

--- a/extensions/chocolatey-core.extension/extensions/Get-PackageCacheLocation.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-PackageCacheLocation.ps1
@@ -24,7 +24,10 @@ function Get-PackageCacheLocation {
         # Name of the package, by default $Env:ChocolateyPackageName
         [string] $Name    = $Env:ChocolateyPackageName,
         # Version of the package, by default $Env:ChocolateyPackageVersion
-        [string] $Version = $Env:ChocolateyPackageVersion
+        [string] $Version = $Env:ChocolateyPackageVersion,
+        # Allows splatting with arguments that do not apply and future expansion. Do not use directly.
+        [parameter(ValueFromRemainingArguments = $true)]
+        [Object[]] $IgnoredArguments
     )
 
     if (!$Name) { Write-Warning 'Environment variable $Env:ChocolateyPackageName is not set' }

--- a/extensions/chocolatey-core.extension/extensions/Get-PackageParameters.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-PackageParameters.ps1
@@ -10,7 +10,15 @@
 .OUTPUTS
     [HashTable]
 #>
-function Get-PackageParameters([string] $Parameters = $Env:ChocolateyPackageParameters) {
+function Get-PackageParameters {
+    [CmdletBinding()]
+    param(
+       [string] $Parameters = $Env:ChocolateyPackageParameters,
+       # Allows splatting with arguments that do not apply and future expansion. Do not use directly.
+       [parameter(ValueFromRemainingArguments = $true)]
+       [Object[]] $IgnoredArguments
+    )
+
     $res = @{}
 
     $re = "\/([a-zA-Z0-9]+)(:([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)?"

--- a/extensions/chocolatey-core.extension/extensions/Get-UninstallRegistryKey.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-UninstallRegistryKey.ps1
@@ -22,6 +22,9 @@
     or common root words to prevent overmatching. For example, "SketchUp*" would match two keys with software
     names "SketchUp 2016" and "SketchUp Viewer" that are different programs released by the same company.
 
+.PARAMETER IgnoredArguments
+    Allows splatting with arguments that do not apply and future expansion. Do not use directly.
+
 .INPUTS
     System.String
 
@@ -55,7 +58,9 @@ function Get-UninstallRegistryKey {
     param(
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [ValidateNotNullOrEmpty()]
-        [string] $SoftwareName
+        [string] $SoftwareName,
+        [parameter(ValueFromRemainingArguments = $true)]
+        [Object[]] $IgnoredArguments
     )
     Write-Debug "Running 'Get-UninstallRegistryKey' for `'$env:ChocolateyPackageName`' with SoftwareName:`'$SoftwareName`'";
 

--- a/extensions/chocolatey-core.extension/extensions/Get-WebContent.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-WebContent.ps1
@@ -43,7 +43,11 @@ function Get-WebContent {
         [string]$Url,
 
         # Additional options for http request.For now only Headers property supported.
-        [hashtable]$Options
+        [hashtable]$Options,
+
+        # Allows splatting with arguments that do not apply and future expansion. Do not use directly.
+        [parameter(ValueFromRemainingArguments = $true)]
+        [Object[]] $IgnoredArguments
     )
 
     $filePath =  get_temp_filepath

--- a/extensions/chocolatey-core.extension/extensions/Register-Application.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Register-Application.ps1
@@ -34,7 +34,11 @@ function Register-Application{
         [string]$Name,
 
         # Register application only for the current user. By default registration is for the machine.
-        [switch]$User
+        [switch]$User,
+
+        # Allows splatting with arguments that do not apply and future expansion. Do not use directly.
+        [parameter(ValueFromRemainingArguments = $true)]
+        [Object[]] $IgnoredArguments
     )
 
     if (!(Test-Path $ExePath)) { throw "Path doesn't exist: $ExePath" }


### PR DESCRIPTION
It is hard to know how future expansion of a PowerShell function is
going to look. When a function is created, it is sometimes set with a
certain number of parameters. When not using `CmdletBinding` other
parameters can be passed and ignored. However, when `CmdletBinding` is
opted into explicitly or implicitly, it doesn't automatically allow for
additional ignored arguments to be passed through. In fact, it out right
errors when you pass more than the arguments that are present. It also
does not allow for splatting with more parameters than are used for a
particular function. This is suboptimal.

Fortunately, for functions with `CmdletBinding`, an additional catch all
parameter can be added to the end to see the other parameters and add
them as part of the function. This allows for future expansion and
allows for older versions of the function to gracefully adapt when
new parameters have been added to the function (they simply ignore
what they don't know about).

Add `IgnoredArguments` to each of the functions in the extensions to
allow for gracefully allowing future expansion and for splatting.

This was seen in Chocolatey's code base in https://github.com/chocolatey/choco/commit/4ee8818d505df99b550041b7dc2c82b3bd909f4f
when it added documentation and needed to enable CmdletBinding to
produce proper docs.

Fixes #621 