### PR TITLE
(rukerneltool) Added missing licenseUrl

### DIFF
--- a/automatic/rukerneltool/rukerneltool.nuspec
+++ b/automatic/rukerneltool/rukerneltool.nuspec
@@ -8,6 +8,7 @@
     <owners>chocolatey</owners>
     <authors>Rainer Ullrich</authors>
     <projectUrl>http://rukerneltool.rainerullrich.de/</projectUrl>
+    <licenseUrl>http://rukerneltool.com/_Kurzanleitung_.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
 Universal flash-, upload- and recovery-tool for AVM Fritz!Box.


### PR DESCRIPTION
See <https://github.com/chocolatey/chocolatey-coreteampackages/issues/146>.  Unfortunately, the license is just thrown into the Quick Start guide, which is available only in German.