### PR TITLE
(flashplayer*): use XML download instead of HTML scraping

### DIFF
--- a/automatic/flashplayeractivex/update.ps1
+++ b/automatic/flashplayeractivex/update.ps1
@@ -2,7 +2,7 @@
 import-module au
 . "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
-$releases = "https://get.adobe.com/en/flashplayer/" # URL to for GetLatest
+$releases = 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_win_pl.xml'
 $padVersionUnder = '24.0.1'
 
 function global:au_BeforeUpdate {
@@ -27,13 +27,10 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
 
-  $HTML = Invoke-WebRequest -Uri $releases
-  $try = ($HTML.ParsedHtml.getElementsByTagName('p') | Where{ $_.className -eq 'NoBottomMargin' } ).innerText
-  $try = $try  -split "\r?\n"
-  $try = $try[0] -replace ' ', ' = '
-  $try =  ConvertFrom-StringData -StringData $try
-  $CurrentVersion = ( $try.Version )
-  $majorVersion = ([version] $CurrentVersion).Major
+  $XML = New-Object  System.Xml.XmlDocument
+  $XML.load($releases)
+  $currentVersion = $XML.XML.update.version.replace(',', '.')
+  $majorVersion = ([version]$currentVersion).Major
 
   $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_active_x.msi"
 

--- a/automatic/flashplayerplugin/update.ps1
+++ b/automatic/flashplayerplugin/update.ps1
@@ -1,7 +1,7 @@
 ﻿import-module au
 . "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
-$releases = 'https://get.adobe.com/flashplayer/'
+$releases = 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_win_pl.xml'
 $padVersionUnder = '24.0.1'
 
 function global:au_SearchReplace {
@@ -17,14 +17,10 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   
-  $HTML = Invoke-WebRequest -UseBasicParsing -Uri $releases
-  $try = ($HTML.ParsedHtml.getElementsByTagName('p') | Where{ $_.className -eq 'NoBottomMargin' } ).innerText
-  $try = $try  -split "\r?\n"
-  $try = $try[0] -replace ' ', ' = '
-  $try =  ConvertFrom-StringData -StringData $try
-  $version = ( $try.Version )
+  $XML = New-Object  System.Xml.XmlDocument
+  $XML.load($releases)
+  $version = $XML.XML.update.version.replace(',', '.')
   $major_version = ([version]$version).Major
-  $HTML.close
   
     @{
         Version = Get-Padded-Version $version $padVersionUnder

--- a/automatic/flashplayerppapi/update.ps1
+++ b/automatic/flashplayerppapi/update.ps1
@@ -1,7 +1,7 @@
 ﻿import-module au
 . "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
-$releases = "https://get.adobe.com/en/flashplayer/" # URL to for GetLatest
+$releases = 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_win_pl.xml'
 $padVersionUnder = '24.0.1'
 
 function global:au_BeforeUpdate {
@@ -24,13 +24,10 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
 
-  $HTML = Invoke-WebRequest -Uri $releases
-  $try = ($HTML.ParsedHtml.getElementsByTagName('p') | Where{ $_.id -eq 'AUTO_ID_columnleft_p_version' } ).innerText
-  $try = $try  -split "\r?\n"
-  $try = $try[0] -replace ' ', ' = '
-  $try =  ConvertFrom-StringData -StringData $try
-  $currentVersion = ( $try.Version )
-  $majorVersion = ([version] $currentVersion).Major
+  $XML = New-Object  System.Xml.XmlDocument
+  $XML.load($releases)
+  $currentVersion = $XML.XML.update.version.replace(',', '.')
+  $majorVersion = ([version]$currentVersion).Major
 
   $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${currentVersion}/install_flash_player_${majorVersion}_ppapi.msi"
 


### PR DESCRIPTION
I am eagerly waiting for the security updates from last week, so I took a shot.
Testing and reading through #628 I verified that `-UseBasicParsing` is the issue here because the `ParsedHtml` member does not exist. The XML based approach in this PR is a little cleaner imho and it's also what the people over at [autopkg](https://github.com/autopkg/recipes/blob/master/AdobeFlashPlayer/AdobeFlashURLProvider.py) use. Note that I am very new to chocolatey packages and I have no idea what `$padVersionUnder` is for :grin: 