### PR TITLE
(flashplayer*) fix dot selection for XML object

### DIFF
--- a/automatic/flashplayeractivex/update.ps1
+++ b/automatic/flashplayeractivex/update.ps1
@@ -29,7 +29,7 @@ function global:au_GetLatest {
 
   $XML = New-Object  System.Xml.XmlDocument
   $XML.load($releases)
-  $currentVersion = $XML.XML.update.version.replace(',', '.')
+  $currentVersion = $XML.XML[1].update.version.replace(',', '.')
   $majorVersion = ([version]$currentVersion).Major
 
   $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${CurrentVersion}/install_flash_player_${majorVersion}_active_x.msi"

--- a/automatic/flashplayerplugin/update.ps1
+++ b/automatic/flashplayerplugin/update.ps1
@@ -19,7 +19,7 @@ function global:au_GetLatest {
   
   $XML = New-Object  System.Xml.XmlDocument
   $XML.load($releases)
-  $version = $XML.XML.update.version.replace(',', '.')
+  $version = $XML.XML[1].update.version.replace(',', '.')
   $major_version = ([version]$version).Major
   
     @{

--- a/automatic/flashplayerppapi/update.ps1
+++ b/automatic/flashplayerppapi/update.ps1
@@ -26,7 +26,7 @@ function global:au_GetLatest {
 
   $XML = New-Object  System.Xml.XmlDocument
   $XML.load($releases)
-  $currentVersion = $XML.XML.update.version.replace(',', '.')
+  $currentVersion = $XML.XML[1].update.version.replace(',', '.')
   $majorVersion = ([version]$currentVersion).Major
 
   $url32 = "https://download.macromedia.com/pub/flashplayer/pdc/${currentVersion}/install_flash_player_${majorVersion}_ppapi.msi"


### PR DESCRIPTION
Sorry for the fixup.. I just noticed the dot notation doesn't work with Powershell v2. Is this an issue? The explicit index for the XML collection solves this.