### PR TITLE
(7zip.install) improved and added shim

### DIFF
--- a/automatic/7zip.install/7zip.install.nuspec
+++ b/automatic/7zip.install/7zip.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>7zip.install</id>
     <title>7-Zip (Install)</title>
-    <version>16.4.0</version>
+    <version>16.04</version>
     <authors>Igor Pavlov</authors>
     <owners>chocolatey,Rob Reynolds</owners>
     <summary>7-Zip is a file archiver with a high compression ratio.</summary>

--- a/automatic/7zip.install/7zip.install.nuspec
+++ b/automatic/7zip.install/7zip.install.nuspec
@@ -3,13 +3,14 @@
   <metadata>
     <id>7zip.install</id>
     <title>7-Zip (Install)</title>
-    <version>16.04</version>
+    <version>16.4.0.20170401</version>
     <authors>Igor Pavlov</authors>
     <owners>chocolatey,Rob Reynolds</owners>
     <summary>7-Zip is a file archiver with a high compression ratio.</summary>
     <description>7-Zip is a file archiver with a high compression ratio.
 
 ## Features
+
 - High compression ratio in [7z format](http://www.7-zip.org/7z.html) with **LZMA** and **LZMA2** compression
 - Supported formats:
   - Packing / unpacking: 7z, XZ, BZIP2, GZIP, TAR, ZIP and WIM
@@ -24,12 +25,13 @@
 - Localizations for 87 languages
 
 ## Notes
+
 - The installer for 7-Zip is known to close the explorer process.
   This means you may lose current work. If it doesn't automatically restart explorer, type `explorer` on the command shell to restart it.
     </description>
     <projectUrl>http://www.7-zip.org/</projectUrl>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/7zip.install</packageSourceUrl>
-    <tags>7zip zip archiver admin foss</tags>
+    <tags>7zip zip archiver admin cross-platform cli foss</tags>
     <licenseUrl>http://www.7-zip.org/license.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/68b91a851cee97e55c748521aa6da6211dd37c98/icons/7zip.svg</iconUrl>
@@ -38,7 +40,7 @@
     <bugTrackerUrl>https://sourceforge.net/p/sevenzip/_list/tickets?source=navbar</bugTrackerUrl>
     <releaseNotes>http://www.7-zip.org/history.txt</releaseNotes>
     <dependencies>
-      <dependency id="chocolatey-core.extension" version="1.0.4" />
+      <dependency id="chocolatey-core.extension" version="1.2" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/7zip.install/7zip.install.nuspec
+++ b/automatic/7zip.install/7zip.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>7zip.install</id>
     <title>7-Zip (Install)</title>
-    <version>16.4.0.20170401</version>
+    <version>16.4.0</version>
     <authors>Igor Pavlov</authors>
     <owners>chocolatey,Rob Reynolds</owners>
     <summary>7-Zip is a file archiver with a high compression ratio.</summary>

--- a/automatic/7zip.install/tools/chocolateyInstall.ps1
+++ b/automatic/7zip.install/tools/chocolateyInstall.ps1
@@ -1,37 +1,26 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-. "$toolsDir\helpers.ps1"
-
-$initialProcessCount = Get-ExplorerProcessCount
-Write-Warning "This installer is known to close the explorer process. This means `nyou may lose current work. `nIf it doesn't automatically restart explorer, type 'explorer' on the `ncommand shell to restart it."
-
-$filePath32 = "$toolsDir\7zip_x32.exe"
-$filePath64 = "$toolsDir\7zip_x64.exe"
-
 $filePath = if ((Get-ProcessorBits 64) -and $env:chocolateyForceX86 -ne $true) {
-  Write-Host "Installing 64 bit version" ; $filePath64
-} else { Write-Host "Installing 32 bit version" ; $filePath32 }
+       Write-Host "Installing 64 bit version" ; gi $toolsDir\*_x32.exe }
+else { Write-Host "Installing 32 bit version" ; gi $toolsDir\*_x64.exe }
 
 $packageArgs = @{
   packageName    = '7zip.install'
   fileType       = 'exe'
   softwareName   = '7-zip*'
-  file           = "$filePath"
+  file           = $filePath
   silentArgs     = '/S'
   validExitCodes = @(0)
 }
-
-# To prevent shimming of installers
-"" | Out-File "$filePath32.ignore"
-"" | Out-File "$filePath64.ignore"
-
 Install-ChocolateyInstallPackage @packageArgs
+rm $toolsDir\*.exe -ea 0 -force
 
-$finalProcessCount = Get-ExplorerProcessCount
-if($initialProcessCount -lt $finalProcessCount)
-{
-  Start-Process explorer.exe
-}
+# 7z installer may close explorer
+if (!(ps explorer -ea 0)) { start explorer.exe }
 
-Remove-Item "$filePath32*","$filePath64*" -Force -ea 0
+$installLocation = Get-AppInstallLocation $packageArgs.softwareName
+if (!$installLocation)  { Write-Warning "Can't find 7zip install location"; return }
+Write-Host "7zip installed to '$installLocation'"
+
+Install-BinFile '7z' $installLocation\7z.exe

--- a/automatic/7zip.install/tools/helpers.ps1
+++ b/automatic/7zip.install/tools/helpers.ps1
@@ -1,6 +1,0 @@
-Function Get-ExplorerProcessCount
-{
-  $process = Get-Process explorer -ErrorAction SilentlyContinue
-  $processCount = ($process | Measure-Object).Count
-  return $processCount
-}

--- a/automatic/7zip.install/update.ps1
+++ b/automatic/7zip.install/update.ps1
@@ -2,10 +2,7 @@
 
 $softwareNamePrefix = '7-zip'
 
-function global:au_BeforeUpdate {
-  Get-RemoteFiles -Purge -FileNameBase '7zip'
-  $Latest.ChecksumType = 'sha256'
-}
+function global:au_BeforeUpdate { Get-RemoteFiles -Purge -FileNameBase '7zip' }
 
 function global:au_SearchReplace {
   @{

--- a/automatic/7zip/update.ps1
+++ b/automatic/7zip/update.ps1
@@ -24,10 +24,10 @@ function global:au_GetLatest {
   if ($Matches[1] -and ($Matches[1] -match '^[\d\.]+$')) { $version = $Matches[0] }
 
   @{
-    URL32 = $domain + $url32
-    URL64 = $domain + $url64
+    URL32     = $domain + $url32
+    URL64     = $domain + $url64
     URL_EXTRA = $domain + $url_extra
-    Version = $version
+    Version   = [version]$version
   }
 }
 


### PR DESCRIPTION
- Simplified installer
- Added shim (closes #549)
- Improved nuspec
- Removed 0 prefix on version


**Notes**:
- I removed helper because that check seems unnecessary - explorer is either running or not.
- This package can now be used as 7zip dependency instead of 7zip.portable