### PR TITLE
(build) Enabled running tests on pull requests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,9 @@
 # AU template: https://github.com/majkinetor/au-packages-template
 
 version: '{build}'
+pull_requests:
+  do_not_increment_build_number: true
 max_jobs: 1
-image: WMF 5
 # History plugin requires complete log
 #clone_depth: 5
 branches:
@@ -33,14 +34,13 @@ environment:
 
   #ID of the gist used to save run results
   gist_id: bd2eaa76f2a9ab739ca0544c502dca6e
-  
+
   #ID of the gist used to save test run results
   gist_id_test: b733b29e320a8c05bc99cc0bf59cd8d1
 
   #Chocolatey API key - to push updated packages
   api_key:
     secure: GLpgZqYKDuf8yWaYGP5KmoHoS4OllLg6lo/ROK9DhSOkaNx7YAv4E1Tn4N3e7Gcn
-
 
 init:
 - git config --global user.email "chocolatey@realdimensions.net"
@@ -51,27 +51,30 @@ install:
 - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
 - ps: $PSVersionTable
 - git --version
+- choco --version
 - ps: |
     git clone -q https://github.com/majkinetor/au.git $Env:TEMP/au
     . "$Env:TEMP/au/scripts/Install-AU.ps1" $Env:au_version
-
 - ps: |
     "Build info"
     '  {0,-20} {1}' -f 'SCHEDULED BUILD:', ($Env:APPVEYOR_SCHEDULED_BUILD -eq 'true')
     '  {0,-20} {1}' -f 'FORCED BUILD:'   , ($Env:APPVEYOR_FORCED_BUILD    -eq 'true')
     '  {0,-20} {1}' -f 'RE BUILD:'       , ($Env:APPVEYOR_RE_BUILD        -eq 'true')
-
 build_script:
 - ps: |
     $ErrorActionPreference = 'Continue'
-
     if ($Env:APPVEYOR_PROJECT_NAME  -like '*test*') { ./test_all.ps1 "random $Env:au_test_groups"; return }
-
+    if (($Env:APPVEYOR_PULL_REQUEST_NUMBER -ne $null) -and ($Env:APPVEYOR_PULL_REQUEST_NUMBER -ne '')) {
+      ./scripts/Test-RepoPackage.ps1 -CleanFiles -TakeScreenshots
+      return
+    } else {
+      # Clean the choco logs as it's quite large
+      rm "$env:ChocolateyInstall\logs\*.log"
+    }
     if ( ($Env:APPVEYOR_SCHEDULED_BUILD -ne 'true') -and ($Env:APPVEYOR_FORCED_BUILD -ne 'true') ) {
         switch -regex ($Env:APPVEYOR_REPO_COMMIT_MESSAGE)
         {
             '\[AU (.+?)\]'   { $forced = $Matches[1] }
-
             '\[PUSH (.+?)\]' {
                 $packages = $Matches[1] -split ' '
                 Write-Host "PUSHING PACKAGES: $packages"
@@ -87,12 +90,16 @@ build_script:
     }
 
     ./update_all.ps1 -ForcedPackages $forced
-    7z a au_temp.zip $Env:TEMP\chocolatey\au\*
 
 artifacts:
 - path: update_info.xml
 - path: Update-AUPackages.md
-- path: au_temp.zip
+
+on_finish:
+- 7z a -mx9 choco_logs.7z "%ChocolateyInstall%\logs\*"
+- ps: if (Test-Path $Env:TEMP\chocolatey\au) { 7z a  -mx9 au_temp.7z $Env:TEMP\chocolatey\au\* ; Push-AppveyorArtifact au_temp.7z }
+- appveyor PushArtifact choco_logs.7z
+#- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 notifications:
 - provider: Email
@@ -100,6 +107,3 @@ notifications:
   on_build_success: false
   on_build_failure: true
   on_build_status_changed: true
-
-#on_finish:
-#- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/scripts/Take-Screenshot.ps1
+++ b/scripts/Take-Screenshot.ps1
@@ -1,0 +1,27 @@
+﻿# Based on FeodorFitsners screenshot function
+# https://github.com/FeodorFitsner/selenium-tests/blob/master/take-screenshot.ps1
+
+function Take-Screenshot {
+  param(
+    [string]$file,
+    [ValidateSet('bmp','jpeg','png')]
+    [string]$imagetype = 'png'
+  )
+  [void][Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms")
+  [void][Reflection.Assembly]::LoadWithPartialName('System.Drawing')
+  function screenshot([Drawing.Rectangle]$bounds, $path, [Drawing.Imaging.ImageFormat]$imageFormat) {
+    $bitmap = New-Object Drawing.Bitmap $bounds.width, $bounds.height
+    $graphics = [Drawing.Graphics]::FromImage($bitmap)
+
+    $graphics.CopyFromScreen($bounds.Location, [Drawing.Point]::Empty, $bounds.size)
+    $bitmap.Save($path, $imageFormat)
+
+    $graphics.Dispose()
+    $bitmap.Dispose()
+  }
+
+  $screen = [System.Windows.Forms.Screen]::PrimaryScreen
+  $bounds = $screen.Bounds
+
+  screenshot $bounds $file $imagetype
+}

--- a/scripts/Test-RepoPackage.ps1
+++ b/scripts/Test-RepoPackage.ps1
@@ -1,0 +1,633 @@
+﻿<#
+.SYNOPSIS
+  Test the au updating of changed packages, as well as the install and uninstall of those packages.
+
+.DESCRIPTION
+  This script uses git to get all the packages that have changed since it diverged from the
+  master branch and runs those packages through au updating (only if they are automatic packages),
+  tries to install them and also tries to uninstall those packages.
+  It also accepts an optional packageName that overrides the check for changed packages.
+
+.PARAMETER packageName
+  An optional value accepting a single package name.
+  If this variable is not specified, or if it's set to $null it gets the package
+  name from changed files.
+
+.PARAMETER type
+  An optional variable that can be used to specify which kind of tests that should
+  be run.
+  If the value is set to 'all' (the default) all tests will be run.
+
+.PARAMETER CleanFiles
+  If this variable have been specified the script will clean all
+  chocolatey logs, au output files and the nupkg files already existing
+  in the repository before running the tests.
+
+.PARAMETER TakeScreenshots
+  If this variable have been provided, the script will take a screenshot
+  of the user desktop after install/uninstall as well as when the message
+  'Failures' have been outputted by the choco executable.
+
+.PARAMETER chocoCommandTimeout
+  The timeout that should be passed to choco when installing/uninstalling
+  packages (defaults to 600 seconds, or 10 minutes)
+
+.PARAMETER timeoutBeforeScreenshot
+  The amount of seconds to sleep after installing/uninstalling a package
+  and before taking the screenshot.
+
+.PARAMETER screenShotDir
+  The directory to where the scrip should save all taken screenshots.
+  (The directory does not need to exist before running the script)
+
+.EXAMPLE
+  .\Test-RepoPackage.ps1
+#>
+param(
+  [string]$packageName = $null,
+  [ValidateSet('all','update','install','uninstall','none')]
+  [string]$type = 'all',
+  [switch]$CleanFiles,
+  [switch]$TakeScreenshots,
+  [int]$chocoCommandTimeout = 600,
+  [int]$timeoutBeforeScreenshot = 1,
+  [string]$screenShotDir = "$env:TEMP\screenshots"
+)
+
+function WriteOutput() {
+<#
+.SYNOPSIS
+  Simple helper function to simplify
+  the different output methods we use.
+#>
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string]$text,
+    [ValidateSet('Error','Warning','ChocoError','ChocoWarning','ChocoInfo','Normal')]
+    [string]$type = 'Normal'
+  )
+   switch -Exact ($type) {
+    'Error' { Write-Error $text }
+    'Warning' { Write-Warning $text }
+    'ChocoError' { Write-Host $text -ForegroundColor Black -BackgroundColor Red }
+    'ChocoWarning' { Write-Host $text -ForegroundColor Black -BackgroundColor Yellow }
+    'ChocoInfo' { Write-Host $text -ForegroundColor White -BackgroundColor Black }
+    Default { Write-Host $text }
+  }
+}
+
+function WriteChocoOutput() {
+<#
+.SYNOPSIS
+  A simple helper function for processing the output of choco.
+  Only meant to handle the colorization of text.
+#>
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string]$text
+  )
+  begin {}
+  process {
+    switch -Regex ($text) {
+      '^\s*ERROR|\s*Failures|^Uninstall may not be silent' { WriteOutput $text -type ChocoError }
+      '^\s*WARNING' { WriteOutput $text -type ChocoWarning }
+      Default { WriteOutput $text -type ChocoInfo }
+    }
+  }
+  end {}
+}
+
+function CleanFiles() {
+<#
+.SYNOPSIS
+  The function responsible for cleaning out temporary
+  files before we run the tests.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$screenShotDir
+  )
+  $pathsToClean = @(
+    "$env:ChocolateyInstall\logs\*"
+    "$env:TEMP\chocolatey\au\*"
+    "$PSScriptRoot\..\Update-Force-Test*.md"
+  )
+  if ($TakeScreenshots) { $pathsToClean += @("$screenShotDir\*") }
+  $pathsToClean += Get-ChildItem -Recurse "$PSScriptRoot\.." -Filter "*.nupkg" | select -Expand FullName
+
+  $pathsToClean | % {
+    if (Test-Path $_) { rm $_ -Recurse }
+  }
+}
+
+function GetDependentPackage() {
+<#
+.SYNOPSIS
+  Function responsible for aquiring a meta package(s) dependency.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$packageDirectory
+  )
+  $packageName = $PackageDirectory -split '[\/\\]' | select -last 1
+  $nuspecPath = Get-Item "$PackageDirectory\*.nuspec"
+  $content = Get-Content -Encoding UTF8 $nuspecPath
+  $Matches = $null
+  $content | ? { $_ -match "\<dependency.*id=`"(${packageName}.(install|portable|app|commandline))" } | select -First 1 | WriteOutput
+  $result = if ($Matches) { $Matches[1].ToLowerInvariant() } else { $null }
+  return $result
+}
+
+function GetPackagePath() {
+<#
+.SYNOPSIS
+  Gets the full path to the specified package.
+#>
+  param([string]$packageName)
+  if ($packageName -eq $null -or $packageName -eq '') {
+    return $null
+  }
+  $sourcePath = gci "$PSScriptRoot\.." -Recurse -Filter "$packageName.nuspec" | select -First 1 -Expand Directory
+  if (!$sourcePath) {
+    WriteOutput "No path was found for the package: $packageName" -type Warning
+  }
+  return $sourcePath
+}
+
+function GetPackageSelectQuery() {
+  param(
+    [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+    $InputObject
+  )
+  begin { $queries = @() }
+  process {
+    $queries += $InputObject | select `
+      @{Name = 'NuspecPath'; Expression = {Resolve-Path "$_\*.nuspec"}},
+      @{Name = 'Directory'; Expression = {Resolve-Path $_}},
+      @{Name = 'Name'; Expression = {[System.IO.Path]::GetFileName($_).ToLowerInvariant()}},
+      @{Name = 'IsAutomatic'; Expression = {$_ -match 'automatic[\/\\]'}},
+      @{Name = 'DependentPackage'; Expression = {GetDependentPackage -packageDirectory $_}}
+  }
+  end {
+    $queries
+   }
+}
+
+function GetPackagesFromDiff() {
+<#
+  Gets the changed packages that have changed since the
+  latest common ancestor of the current branch, and the specified $diffAgainst branch.
+
+.PARAMETER diffAgainst
+  The branch we should run git diff against.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNull()]
+    [string]$diffAgainst
+  )
+  $paths = git diff "${diffAgainst}..." --name-only | % {
+    if ($_.StartsWith('..')) {
+      $path = Split-Path -Parent $_
+    } else {
+      $path = Split-Path -Parent (Resolve-Path -Relative "$PSScriptRoot\..\$_")
+    }
+    while ($path -and !(Test-Path "$path\*.nuspec")) {
+      $path = Split-Path -Parent $path
+    }
+    if ($path) { $path }
+  } | select -Unique
+
+  return $paths | GetPackageSelectQuery
+}
+
+function GetPackagesFromName() {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$packageName
+  )
+  return Get-ChildItem "$PSScriptRoot\..\" -Recurse -Filter "$packageName.nuspec" | select -Unique -expand Directory | GetPackageSelectQuery
+}
+
+function MoveLogFile() {
+<#
+.SYNOPSIS
+  Renames the chocolatey.log file to a file matching the specified packageName and commandType
+  so it only contains the necessary log for the current package.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$packageName,
+    [Parameter(Mandatory = $true)]
+    [string]$commandType
+  )
+
+  if (Test-Path "$env:ChocolateyInstall\logs\chocolatey.log") {
+    mv "$env:ChocolateyInstall\logs\chocolatey.log" "$env:ChocolateyInstall\logs\${commandType}_${packageName}.log" | WriteOutput
+  }
+}
+
+function RemoveDependentPackages() {
+  param(
+    [object]$packages
+  )
+
+  [array]$dependentPackages = $packages | ? { $_.DependentPackage -ne $null -and $_.DependentPackage -ne '' } | select -expand DependentPackage
+  if ($dependentPackages -ne $null -and $dependentPackages.Count -gt 0) {
+    $packages = $packages | ? { !$dependentPackages.Contains($_.Name) }
+  }
+  return $packages
+}
+
+function RunChocoPackProcess() {
+<#
+.SYNOPSIS
+  Function responsible for running choco pack when a nupkg file have not already been created.
+#>
+  param([string]$path)
+  if ($path -ne $null -and $path -ne '') { pushd $path }
+  if (!(Test-Path "*.nupkg")) {
+    . choco pack | WriteChocoOutput
+    if ($LastExitCode -ne 0) { popd; throw "Choco pack failed with code: $LastExitCode"; return }
+  }
+  if ($path -ne $null -and $path -ne '') { popd}
+}
+
+function SetAppveyorExitCode() {
+<#
+.SYNOPSIS
+  Sets the exit code of the script when running on appveyor, so
+  the build would fail when necessary.
+#>
+  param(
+    [int]$ExitCode
+  )
+  WriteOutput "Exit code was $ExitCode" -type Warning
+
+  if (!(Test-Path env:\APPVEYOR)) {
+    return
+  }
+  if ($ExitCode -ne 0) {
+    $host.SetShouldExit($ExitCode)
+  }
+}
+
+function UploadAppveyorArtifact() {
+<#
+.SYNOPSIS
+  Uploads the specified filePaths to appveyor when a appveyor build
+  is currently running.
+#>
+  param(
+    [string[]]$filePaths
+  )
+
+  if (Test-Path env:\APPVEYOR) {
+    $filePaths | ? { Test-Path $_ } | % { Push-AppveyorArtifact $_ -FileName (Split-Path -Leaf $_)}
+  }
+}
+
+function RunChocoProcess() {
+<#
+  Function responsible for running choco install/uninstall
+  and handling choco failures.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$arguments,
+    [Parameter(Mandatory = $true)]
+    [int]$timeout,
+    [Parameter(Mandatory = $true)]
+    [bool]$takeScreenshot,
+    [Parameter(Mandatory = $true)]
+    [int]$timeoutBeforeScreenshot,
+    [Parameter(Mandatory = $true)]
+    [string]$screenShotDir
+  )
+
+  $res = $true
+  $args = @($arguments) + @(
+    '--yes'
+    "--execution-timeout=$timeout"
+  )
+  if ($arguments[0] -eq 'install') {
+    $args += @(
+      '--requirechecksum'
+    )
+  } else {
+    $args += @(
+      '--all-versions'
+      '--autouninstaller'
+      '--fail-on-autouninstaller'
+    )
+  }
+  $packFailed = $false
+  $errorFilePath = "$screenShotDir\$($arguments[0])Error_$($arguments[1]).jpg"
+  if (!(Test-Path "$screenShotDir")) { mkdir "$screenShotDir" -Force | Out-Null }
+
+  try {
+    RunChocoPackProcess '' | WriteChocoOutput
+    $failureOccurred = $false
+    $previousPercentage = -1;
+    $progressRegex = 'Progress\:.*\s+([\d]+)\%'
+    . choco $args | % {
+      $matches = $null
+      if ($failureOccurred) { WriteOutput $_ -type ChocoError }
+       # We are only showing progress per 10th value
+      elseif([regex]::IsMatch($_, $progressRegex)) {
+        $progressMatch = [regex]::Match($_, $progressRegex).Groups[1].Value
+        if (($progressMatch % 10) -eq 0) {
+          if ($progressMatch -ne $previousPercentage) {
+            WriteChocoOutput $_
+          }
+          $previousPercentage = $progressMatch
+        }
+      }
+      else { WriteChocoOutput $_ }
+
+      if ($_ -match "Failures") {
+        $failureOccurred = $true
+        $res = $false
+        # Allow everything to complete before we continue
+        sleep -Seconds 5
+        if ($takeScreenshot) {
+          Take-ScreenShot -file $errorFilePath -imagetype jpeg
+          # Wait for a second so the screenshot can be taken before we continue
+          sleep -Seconds 1
+        }
+        if ($arguments[0] -eq 'uninstall') {
+          Stop-Process -ProcessName "unins*" -ErrorAction Ignore
+        }
+
+        Stop-Process -ProcessName "*$($arguments[1])*" -ErrorAction Ignore
+      }
+    }
+  } finally {
+    if ($LastExitCode -ne 0) {
+      SetAppveyorExitCode $LastExitCode
+      $res = $false
+    }
+    if ($takeScreenshot -and !$packFailed) {
+      if ($timeoutBeforeScreenshot -gt 0) { sleep -Seconds $timeoutBeforeScreenshot }
+      WriteOutput "Taking screenshot after $($arguments[0])"
+      # We take a screenshot when install/uninstall have finished to see if a program have started that isn't monitored by choco
+      $filePath = "$screenShotDir\$($arguments[0])_$($arguments[1]).jpg"
+      Take-ScreenShot -file $filePath -imagetype jpeg
+      UploadAppveyorArtifact $errorFilePath,$filePath
+    }
+  }
+  return $res
+}
+
+function InstallPackage() {
+<#
+.SYNOPSIS
+  Function responsible for testing the installation of a single package.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    $package,
+    [Parameter(Mandatory = $true)]
+    [int]$chocoCommandTimeout,
+    [Parameter(Mandatory = $true)]
+    [int]$screenshotTimeout,
+    [Parameter(Mandatory = $true)]
+    [bool]$takeScreenshot,
+    [Parameter(Mandatory = $true)]
+    [string]$screenShotDir
+  )
+
+  $dependentSource = GetPackagePath -packageName $package.DependentPackage
+  if ($dependentSource) {
+    try {
+      RunChocoPackProcess -path $dependentSource | WriteChocoOutput
+    } catch {
+      WriteOutput $_ -type Error
+      return $package.Name
+    }
+    $sources = "$($_.Directory);$dependentSource;chocolatey"
+  } else {
+    $sources = "$($_.Directory);chocolatey"
+  }
+
+  $arguments = @{
+    timeout = $chocoCommandTimeout
+    takeScreenshot = $takeScreenshot
+    timeoutBeforeScreenshot = $screenshotTimeout
+    arguments = 'install',$package.Name,"--source=`"$sources`""
+    screenShotDir = $screenShotDir
+  }
+
+  try {
+  if (!(RunChocoProcess @arguments)) { return $package.Name }
+  } catch {
+    WriteOutput $_ -type Error
+    return $package.Name
+  }
+
+  return ""
+}
+
+function TestAuUpdatePackages() {
+<#
+.SYNOPSIS
+  Function responsible for running au on the specified packages.
+#>
+  param(
+    $packages
+  )
+  [array]$packageNames = $packages | ? IsAutomatic | select -expand Name
+  $packageNames += $packages | ? { $_.DependentPackage -ne $null -and $_.DependentPackage -ne '' } | select -expand DependentPackage
+  if (!$packageNames) {
+    WriteOutput "No Automatic packages was found. Skipping AU update test."
+    return
+  }
+
+  try {
+    pushd "$PSScriptRoot\.."
+    .\test_all.ps1 -Name $packageNames -ThrowOnErrors
+  } catch {
+    SetAppveyorExitCode $LastExitCode
+    throw "An exception ocurred during AU update. Cancelling all other checks."
+  } finally {
+    MoveLogFile -packageName 'au' -commandType 'update'
+    popd
+  }
+}
+
+function TestInstallAllPackages() {
+<#
+.SYNOPSIS
+  Function responsible for running the install tests on the specified packages.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    $packages,
+    [Parameter(Mandatory = $true)]
+    [int]$chocoCommandTimeout,
+    [Parameter(Mandatory = $true)]
+    [int]$screenshotTimeout,
+    [Parameter(Mandatory = $true)]
+    [bool]$takeScreenshot,
+    [Parameter(Mandatory = $true)]
+    [string]$screenShotDir,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [object[]]$ignoredValues
+  )
+
+  $packages | % {
+    pushd $_.Directory
+    InstallPackage `
+      -package $_ `
+      -chocoCommandTimeout $chocoCommandTimeout `
+      -screenshotTimeout $screenshotTimeout `
+      -takeScreenshot $takeScreenshot `
+      -screenShotDir $screenShotDir
+    MoveLogFile -packageName $_.Name -commandType 'install'
+    popd
+  } | ? { $_ -ne $null -and $_ -ne '' }
+}
+
+function UninstallPackage() {
+<#
+.SYNOPSIS
+  Function responsible for testing the uninstallation of a single package.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    $package,
+    [Parameter(Mandatory = $true)]
+    [int]$chocoCommandTimeout,
+    [Parameter(Mandatory = $true)]
+    [int]$screenshotTimeout,
+    [Parameter(Mandatory = $true)]
+    [bool]$takeScreenshot,
+    [Parameter(Mandatory = $true)]
+    [string]$screenShotDir
+  )
+
+  $dependentSource = GetPackagePath -packageName $package.DependentPackage
+  if ($dependentSource) {
+    try {
+      RunChocoPackProcess -path $dependentSource | WriteOutput
+    } catch {
+      WriteOutput $_ -type Error
+      return $package.Name
+    }
+    $packageNames = @($package.Name ; $package.DependentPackage)
+  } else {
+    $packageNames = @($package.Name)
+  }
+
+  $arguments = @{
+    timeout = $chocoCommandTimeout
+    takeScreenshot = $takeScreenshot
+    timeoutBeforeScreenshot = $screenshotTimeout
+    arguments = @('uninstall';$packageNames)
+    screenShotDir = $screenShotDir
+  }
+  try {
+    if (!(RunChocoProcess @arguments)) { return $package.Name }
+  } catch {
+    WriteOutput $_ -type Error
+    return $package.Name
+  }
+
+  return ""
+}
+
+function TestUninstallAllPackages() {
+<#
+.SYNOPSIS
+  Function responsible for running the uninstall tests on the specified packages.
+  But only if the package names isn't listed in the specified failedInstall object array.
+#>
+  param(
+    [Parameter(Mandatory = $true)]
+    $packages,
+    [Parameter(Mandatory = $true)]
+    [int]$chocoCommandTimeout,
+    [Parameter(Mandatory = $true)]
+    [int]$screenshotTimeout,
+    [Parameter(Mandatory = $true)]
+    [bool]$takeScreenshot,
+    [Parameter(Mandatory = $true)]
+    [string]$screenShotDir,
+    [object[]]$failedInstalls,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [object[]]$ignoredValues
+  )
+
+  $packages | % {
+    $name = $_.Name
+    $packageFailed = $failedInstalls | ? { $_ -eq $name }
+    if ($packageFailed) {
+      WriteOutput "$name failed to install, skipping uninstall test..." -type Warning
+      return ""
+    } else {
+      pushd $_.Directory
+      UninstallPackage `
+        -package $_ `
+        -chocoCommandTimeout $chocoCommandTimeout `
+        -screenshotTimeout $screenshotTimeout `
+        -takeScreenshot $takeScreenshot `
+        -screenShotDir $screenShotDir
+      MoveLogFile -packageName $name -commandType 'uninstall'
+      popd
+    }
+  } | ? { $_ -ne $null -and $_ -ne '' }
+}
+
+if ($packageName) {
+  $packages = GetPackagesFromName -packageName $packageName
+} else {
+  $packages = GetPackagesFromDiff -diffAgainst 'origin/master'
+}
+
+$packages = RemoveDependentPackages -packages $packages
+
+if ($CleanFiles) {
+    CleanFiles -screenShotDir $screenShotDir
+}
+
+if (!$packages) {
+  WriteOutput "No changed packages was found. Exiting tests..." -type Warning
+  return;
+}
+
+if ($TakeScreenshots) { . "$PSScriptRoot\Take-ScreenShot.ps1" }
+$arguments = @{
+  packages = $packages
+  chocoCommandTimeout = $chocoCommandTimeout
+  takeScreenshot = $TakeScreenshots
+  screenShotTimeout = $timeoutBeforeScreenshot
+  screenShotDir = $screenShotDir
+}
+
+switch -Exact ($type) {
+  'update' {
+    TestAuUpdatePackages -packages $packages
+  }
+  'install' {
+    [array]$failedInstalls = TestInstallAllPackages @arguments
+  }
+  'uninstall' {
+    [array]$failedUninstalls = TestUninstallAllPackages @arguments
+   }
+   'none' { WriteOutput "No tests is being run." }
+  Default {
+    TestAuUpdatePackages -packages $packages
+    [array]$failedInstalls = TestInstallAllPackages @arguments
+    [array]$failedUninstalls = TestUninstallAllPackages @arguments -failedInstalls $failedInstalls
+  }
+}
+
+if ($failedInstalls.Count -gt 0) {
+  WriteOutput "The following packages failed to install:" -type ChocoWarning
+  WriteOutput "    $($failedInstalls -join ' ')" -type ChocoWarning
+}
+if ($failedUninstalls.Count -gt 0) {
+  WriteOutput "The following packages failed to uninstall:" -type ChocoWarning
+  WriteOutput "    $($failedUninstalls -join ' ')" -type ChocoWarning
+}

--- a/test_all.ps1
+++ b/test_all.ps1
@@ -1,6 +1,6 @@
 #Name can be 'random N' to randomly force the Nth group of packages.
 
-param( [string[]] $Name, [string] $Root = "$PSScriptRoot\automatic" )
+param( [string[]] $Name, [string] $Root = "$PSScriptRoot\automatic", [switch]$ThrowOnErrors )
 
 if (Test-Path $PSScriptRoot/update_vars.ps1) { . $PSScriptRoot/update_vars.ps1 }
 $global:au_root = Resolve-Path $Root
@@ -44,3 +44,9 @@ $options = [ordered]@{
 
 
 $global:info = updateall -Name $Name -Options $Options
+
+$au_errors = $global:info | ? { $_.Error } | select -ExpandProperty Error
+
+if ($ThrowOnErrors -and $au_errors.Count -gt 0) {
+    throw 'Errors during update'
+}


### PR DESCRIPTION
With this PR we can finally enable tests for updating, installing, uninstalling package(s) on appveyor when a PR is submitted.

The benefit of this is to notice early on when a package update/install/uninstall is failing (although, some positive failures may still occur).
One drawback though, is that the install/uninstall is only subjective and should still also be tested in a choco test environment.

Feel free to test these changes out by opening a PR at https://github.com/AdmiringWorm/chocolatey-coreteampackages/pulls that is based of the test-pkgs-on-pr branch.

@gep13 this is what I suggested to you on sunday, it also requires the Pull Request web hook to be enabled here on github (as I mentioned on gitter).