### PR TITLE
(putty*) Adding support for 64bit putty installer/archive

### DIFF
--- a/automatic/putty.install/legal/VERIFICATION.txt
+++ b/automatic/putty.install/legal/VERIFICATION.txt
@@ -5,12 +5,16 @@ in verifying that this package's contents are trustworthy.
 The extension has been downloaded from their official download link listed on <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>
 and can be verified like this:
 
-1. Download <https://the.earth.li/~sgtatham/putty/latest/w32/putty-0.68-installer.msi>
-2. Then use one of the following methods to obtain the checksum
+
+1. Download the following installers:
+  32-Bit: <https://the.earth.li/~sgtatham/putty/latest/w32/putty-0.68-installer.msi>
+  64-Bit: <https://the.earth.li/~sgtatham/putty/latest/w64/putty-64bit-0.68-installer.msi>
+2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum: 
+  checksum32: 3979670A28D93780D330D1361C0062C543B7E77C7DD96DCAB61C65F9D163843B
+  checksum64: ED33504AF4B91244E7B6026CF90D45E9C2D3BDC6F1656163B0B41D1DAE19BC41
 
 File 'LICENSE.txt' is obtained from <http://www.chiark.greenend.org.uk/~sgtatham/putty/licence.html>

--- a/automatic/putty.install/putty.install.nuspec
+++ b/automatic/putty.install/putty.install.nuspec
@@ -14,10 +14,11 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>PuTTY is a free implementation of Telnet and SSH for Windows and Unix platforms, along with an `xterm` terminal emulator.
 
-## Notes   
-Use of PuTTY, PSCP, PSFTP and Plink is illegal in countries where encryption is outlawed.
-We believe it is legal to use PuTTY, PSCP, PSFTP and Plink in England and Wales and in many other countries, but we are not lawyers, and so if in doubt you should seek legal advice before downloading it.
-You may find useful information at [cryptolaw.org](http://www.cryptolaw.org/), which collects information on cryptography laws in many countries, but we can't vouch for its correctness. 
+## Notes
+- Support for putty 64bit have been added to the package when running chocolatey 0.10.4+, to keep using 32bit version of putty please pass `--x86` when installing/upgrading putty.install *(64bit installation may fail if 32bit is already installed)*
+- Use of PuTTY, PSCP, PSFTP and Plink is illegal in countries where encryption is outlawed.
+- We believe it is legal to use PuTTY, PSCP, PSFTP and Plink in England and Wales and in many other countries, but we are not lawyers, and so if in doubt you should seek legal advice before downloading it.
+- You may find useful information at [cryptolaw.org](http://www.cryptolaw.org/), which collects information on cryptography laws in many countries, but we can't vouch for its correctness.
     </description>
     <summary>PuTTY is a free implementation of Telnet and SSH for Windows and Unix platforms, along with an xterm terminal emulator.</summary>
     <tags>putty telnet ssh admin foss cross-platform</tags>

--- a/automatic/putty.install/tools/chocolateyInstall.ps1
+++ b/automatic/putty.install/tools/chocolateyInstall.ps1
@@ -2,16 +2,15 @@
 
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
-$filePath = "$toolsPath\putty-0.68-installer.msi"
-
 $packageArgs = @{
     PackageName    = "putty.install"
     FileType       = "msi"
     SoftwareName   = "PuTTY"
-    File           = $filePath
+    File           = "$toolsPath\putty-0.68-installer.msi"
+    File64         = "$toolsPath\putty-64bit-0.68-installer.msi"
     SilentArgs     = "/quiet"
     ValidExitCodes = @(0)
 }
 Install-ChocolateyInstallPackage @packageArgs
 
-Remove-Item -Force $filePath -ea 0
+Remove-Item -Force "$toolsPath\*.msi","$toolsPath\*.ignore" -ea 0

--- a/automatic/putty.install/update.ps1
+++ b/automatic/putty.install/update.ps1
@@ -2,35 +2,27 @@
 
 if ($MyInvocation.InvocationName -ne '.') { # run the update only if the script is not sourced
   function global:au_BeforeUpdate {
-    Remove-Item "$PSScriptRoot\tools\*.msi"
-
-    $client = New-Object System.Net.WebClient
-    try
-    {
-      $filePath32 = "$PSScriptRoot\tools\$($Latest.FileName32Installer)"
-      $client.DownloadFile($Latest.URL32Installer, "$filePath32")
-    }
-    finally
-    {
-      $client.Dispose()
-    }
-
-    $Latest.ChecksumType = "sha256"
-    $Latest.Checksum32 = Get-FileHash -Algorithm $Latest.ChecksumType -Path $filePath32 | ForEach-Object Hash
+    $Latest.FileType = 'msi' # could potentially be overridden from putty.portable
+    $Latest.URL32 = $Latest.URL32Installer
+    $Latest.URL64 = $Latest.URL64Installer
+    Get-RemoteFiles -Purge -NoSuffix
   }
 }
 
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt" = @{
-      "(?i)(listed on\s*)\<.*\>" = "`${1}<$releases>"
-      "(?i)(1\..+)\<.*\>"        = "`${1}<$($Latest.URL32Installer)>"
-      "(?i)(checksum type:).*"   = "`${1} $($Latest.ChecksumType)"
-      "(?i)(checksum:).*"        = "`${1} $($Latest.Checksum)"
+      "(?i)(listed on\s*)\<.*\>"  = "`${1}<$releases>"
+      "(?i)(32-Bit.+)\<.*\>"      = "`${1}<$($Latest.URL32)>"
+      "(?i)(64-Bit.+)\<.*\>"      = "`${1}<$($Latest.URL64)>"
+      "(?i)(checksum type:\s+).*" = "`${1}$($Latest.ChecksumType32)"
+      "(?i)(checksum32:).*"       = "`${1} $($Latest.Checksum32)"
+      "(?i)(checksum64:).*"       = "`${1} $($Latest.Checksum64)"
     }
     'tools\chocolateyInstall.ps1' = @{
-      "(PackageName\s*=\s*)`"([^*]+)`"" = "`$1`"$($Latest.PackageName)`""
-      "(^[$]filePath\s*=\s*`"[$]toolsPath\\)(.*)`"" = "`$1$($Latest.FileName32Installer)`""
+      "(PackageName\s*=\s*)`"([^*]+)`""               = "`$1`"$($Latest.PackageName)`""
+      "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\)(.*)`""   = "`$1$($Latest.FileName32)`""
+      "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\)(.*)`"" = "`$1$($Latest.FileName64)`""
     }
   }
 }

--- a/automatic/putty.install/update.ps1
+++ b/automatic/putty.install/update.ps1
@@ -1,6 +1,6 @@
 ﻿. $PSScriptRoot\..\putty\update.ps1
 
-if ($MyInvocation.InvocationName -ne '.') { # run the update only if the script is not sourced
+if ($MyInvocation.InvocationName -ne '.') { # run the BeforeUpdate function only if the script is not sourced
   function global:au_BeforeUpdate {
     $Latest.FileType = 'msi' # could potentially be overridden from putty.portable
     $Latest.URL32 = $Latest.URL32Installer
@@ -27,4 +27,6 @@ function global:au_SearchReplace {
   }
 }
 
-update -ChecksumFor none
+if ($MyInvocation.InvocationName -ne '.') { # run the update only if script is not sourced
+  update -ChecksumFor none
+}

--- a/automatic/putty.portable/legal/VERIFICATION.txt
+++ b/automatic/putty.portable/legal/VERIFICATION.txt
@@ -5,12 +5,15 @@ in verifying that this package's contents are trustworthy.
 The extension has been downloaded from their official download link listed on <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>
 and can be verified like this:
 
-1. Download <https://the.earth.li/~sgtatham/putty/latest/w32/putty.zip>
-2. Then use one of the following methods to obtain the checksum
+1. Download the following archives:
+  32-Bit: <https://the.earth.li/~sgtatham/putty/latest/w32/putty.zip>
+  64-Bit: <https://the.earth.li/~sgtatham/putty/latest/w64/putty.zip>
+2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum: 
+  checksum32: 28A39E97BB2B1B2DF6E0249C2109A1D5ED43612563DDD0E740B1E63A0AAEB0A6
+  checksum64: 082254E1D4B06AD1409EBC2AF5BC59836C0130D63E7ADB79674B99A818307ABE
 
 File 'LICENSE.txt' is obtained from <http://www.chiark.greenend.org.uk/~sgtatham/putty/licence.html>

--- a/automatic/putty.portable/putty.portable.nuspec
+++ b/automatic/putty.portable/putty.portable.nuspec
@@ -14,10 +14,11 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>PuTTY is a free implementation of Telnet and SSH for Windows and Unix platforms, along with an `xterm` terminal emulator.
 
-## Notes   
-Use of PuTTY, PSCP, PSFTP and Plink is illegal in countries where encryption is outlawed.
-We believe it is legal to use PuTTY, PSCP, PSFTP and Plink in England and Wales and in many other countries, but we are not lawyers, and so if in doubt you should seek legal advice before downloading it.
-You may find useful information at [cryptolaw.org](http://www.cryptolaw.org/), which collects information on cryptography laws in many countries, but we can't vouch for its correctness. 
+## Notes
+- Support for putty 64bit have been added to the package when running chocolatey 0.10.4+, to keep using 32bit version of putty please pass `--x86` when installing/upgrading putty.portable
+- Use of PuTTY, PSCP, PSFTP and Plink is illegal in countries where encryption is outlawed.
+- We believe it is legal to use PuTTY, PSCP, PSFTP and Plink in England and Wales and in many other countries, but we are not lawyers, and so if in doubt you should seek legal advice before downloading it.
+- You may find useful information at [cryptolaw.org](http://www.cryptolaw.org/), which collects information on cryptography laws in many countries, but we can't vouch for its correctness.
     </description>
     <summary>PuTTY is a free implementation of Telnet and SSH for Windows and Unix platforms, along with an xterm terminal emulator.</summary>
     <tags>putty telnet ssh foss cross-platform</tags>

--- a/automatic/putty.portable/tools/chocolateyInstall.ps1
+++ b/automatic/putty.portable/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsPath  = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$filePath = "$toolsPath\putty.zip"
 
 $packageArgs = @{
     PackageName  = "putty.portable"
-    FileFullPath = $filePath
+    File         = "$toolsPath\putty_x32.zip"
+    File64       = "$toolsPath\putty_x64.zip"
     Destination  = $toolsPath
 }
 Get-ChocolateyUnzip @packageArgs
 
-Remove-Item -force $filePath -ea 0
+Remove-Item -force "$toolsPath\*.zip" -ea 0

--- a/automatic/putty.portable/update.ps1
+++ b/automatic/putty.portable/update.ps1
@@ -1,37 +1,11 @@
-. $PSScriptRoot\..\putty\update.ps1
+. $PSScriptRoot\..\putty.install\update.ps1
 
 if ($MyInvocation.InvocationName -ne '.') { # run the update only if the script is not sourced
   function global:au_BeforeUpdate {
-    Remove-Item "$PSScriptRoot\tools\*.msi"
-
-    $client = New-Object System.Net.WebClient
-    try
-    {
-      $filePath32 = "$PSScriptRoot\tools\$($Latest.FileName32Portable)"
-      $client.DownloadFile($Latest.URL32Portable, "$filePath32")
-    }
-    finally
-    {
-      $client.Dispose()
-    }
-
-    $Latest.ChecksumType = "sha256"
-    $Latest.Checksum32 = Get-FileHash -Algorithm $Latest.ChecksumType -Path $filePath32 | ForEach-Object Hash
-  }
-}
-
-function global:au_SearchReplace {
-  @{
-    ".\legal\VERIFICATION.txt" = @{
-      "(?i)(listed on\s*)\<.*\>" = "`${1}<$releases>"
-      "(?i)(1\..+)\<.*\>"        = "`${1}<$($Latest.URL32Portable)>"
-      "(?i)(checksum type:).*"   = "`${1} $($Latest.ChecksumType)"
-      "(?i)(checksum:).*"        = "`${1} $($Latest.Checksum)"
-    }
-    'tools\chocolateyInstall.ps1' = @{
-      "(PackageName\s*=\s*)`"([^*]+)`"" = "`$1`"$($Latest.PackageName)`""
-      "(^[$]filePath\s*=\s*`"[$]toolsPath\\)(.*)`"" = "`$1$($Latest.FileName32Portable)`""
-    }
+    $Latest.FileType = 'zip' # could potentially be overridden from putty.install
+    $Latest.URL32 = $Latest.URL32Portable
+    $Latest.URL64 = $Latest.URL64Portable
+    Get-RemoteFiles -Purge
   }
 }
 

--- a/automatic/putty/putty.nuspec
+++ b/automatic/putty/putty.nuspec
@@ -14,10 +14,11 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>PuTTY is a free implementation of Telnet and SSH for Windows and Unix platforms, along with an `xterm` terminal emulator.
 
-## Notes   
-Use of PuTTY, PSCP, PSFTP and Plink is illegal in countries where encryption is outlawed.
-We believe it is legal to use PuTTY, PSCP, PSFTP and Plink in England and Wales and in many other countries, but we are not lawyers, and so if in doubt you should seek legal advice before downloading it.
-You may find useful information at [cryptolaw.org](http://www.cryptolaw.org/), which collects information on cryptography laws in many countries, but we can't vouch for its correctness. 
+## Notes
+- Support for putty 64bit have been added to the package when running chocolatey 0.10.4+, to keep using 32bit version of putty please pass `--x86` when installing/upgrading putty *(64bit installation may fail if 32bit is already installed)*
+- Use of PuTTY, PSCP, PSFTP and Plink is illegal in countries where encryption is outlawed.
+- We believe it is legal to use PuTTY, PSCP, PSFTP and Plink in England and Wales and in many other countries, but we are not lawyers, and so if in doubt you should seek legal advice before downloading it.
+- You may find useful information at [cryptolaw.org](http://www.cryptolaw.org/), which collects information on cryptography laws in many countries, but we can't vouch for its correctness.
     </description>
     <summary>PuTTY is a free implementation of Telnet and SSH for Windows and Unix platforms, along with an xterm terminal emulator.</summary>
     <tags>putty telnet ssh foss cross-platform</tags>
@@ -25,4 +26,6 @@ You may find useful information at [cryptolaw.org](http://www.cryptolaw.org/), w
       <dependency id="putty.portable" version="[0.68]" />
     </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>


### PR DESCRIPTION
This change only is effective if the user have chocolatey version 0.10.4 or later.
Anything sooner would still install the 32bit version.

fixes #646 