### PR TITLE
(googlechrome) Fixed the detection logic for 32bit installs

### DIFF
--- a/automatic/GoogleChrome/GoogleChrome.nuspec
+++ b/automatic/GoogleChrome/GoogleChrome.nuspec
@@ -22,6 +22,9 @@ Chrome is a fast, simple, and secure web browser, built for the modern web.
     <releaseNotes></releaseNotes>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/GoogleChrome</packageSourceUrl>
     <tags>google chrome web internet browser admin</tags>
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.2.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/GoogleChrome/tools/chocolateyInstall.ps1
+++ b/automatic/GoogleChrome/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 . $toolsPath\helpers.ps1
 
-$version = $Env:ChocolateyPackageVersion
+$version = '57.0.2987.133'
 if ($version -eq (Get-ChromeVersion)) {
     Write-Host "Google Chrome $version is already installed."
     return

--- a/automatic/GoogleChrome/tools/chocolateyInstall.ps1
+++ b/automatic/GoogleChrome/tools/chocolateyInstall.ps1
@@ -3,8 +3,8 @@
 
 $version = '57.0.2987.133'
 if ($version -eq (Get-ChromeVersion)) {
-    Write-Host "Google Chrome $version is already installed."
-    return
+  Write-Host "Google Chrome $version is already installed."
+  return
 }
 
 $packageArgs = @{

--- a/automatic/GoogleChrome/tools/helpers.ps1
+++ b/automatic/GoogleChrome/tools/helpers.ps1
@@ -1,29 +1,29 @@
-function Get-Chrome32bitInstalled {
-    $registryPath = 'HKLM:\SOFTWARE\WOW6432Node\Google\Update\ClientState\*'
-    # We also return nothing if the user forces 32bit installation
-    # as we don't need to make any checks in that case.
-    if (!(Test-Path $registryPath) -or $env:ChocolateyForceX86 -eq $true) { return }
+﻿function Get-Chrome32bitInstalled {
+  $registryPath = 'HKLM:\SOFTWARE\WOW6432Node\Google\Update\ClientState\*'
+  # We also return nothing if the user forces 32bit installation
+  # as we don't need to make any checks in that case.
+  if (!(Test-Path $registryPath) -or $env:ChocolateyForceX86 -eq $true) { return }
 
-    $32bitInstalled = gi $registryPath | % {
-        if ((Get-ItemProperty $_.pspath).ap -match 'arch_x86$') { return $true }
-    }
-    if ($32bitInstalled) {
-      return $32bitInstalled
-    }
+  $32bitInstalled = gi $registryPath | % {
+    if ((Get-ItemProperty $_.pspath).ap -match 'arch_x86$') { return $true }
+  }
+  if ($32bitInstalled) {
+    return $32bitInstalled
+  }
 
-    $installLocation = Get-UninstallRegistryKey 'Google Chrome' | % { $_.InstallSource }
-    if ($installLocation) {
-      return Test-Path "$installLocation\nacl_irt_x86_32.nexe"
-    } else {
-      Write-Warning "Unable to find the architecture of the installed Google Chrome application"
-    }
+  $installLocation = Get-UninstallRegistryKey 'Google Chrome' | % { $_.InstallSource }
+  if ($installLocation) {
+    return Test-Path "$installLocation\nacl_irt_x86_32.nexe"
+  } else {
+    Write-Warning "Unable to find the architecture of the installed Google Chrome application"
+  }
 }
 
 function Get-ChromeVersion() {
-    $root   = 'HKLM:\SOFTWARE\Google\Update\Clients'
-    $root64 = 'HKLM:\SOFTWARE\Wow6432Node\Google\Update\Clients'
-    foreach ($r in $root,$root64) {
-        $gcb = gci $r -ea 0 | ? { (gp $_.PSPath).name -eq 'Google Chrome' }
-        if ($gcb) { return $gcb.GetValue('pv') }
-    }
+  $root   = 'HKLM:\SOFTWARE\Google\Update\Clients'
+  $root64 = 'HKLM:\SOFTWARE\Wow6432Node\Google\Update\Clients'
+  foreach ($r in $root,$root64) {
+    $gcb = gci $r -ea 0 | ? { (gp $_.PSPath).name -eq 'Google Chrome' }
+    if ($gcb) { return $gcb.GetValue('pv') }
+  }
 }

--- a/automatic/GoogleChrome/tools/helpers.ps1
+++ b/automatic/GoogleChrome/tools/helpers.ps1
@@ -1,9 +1,21 @@
 function Get-Chrome32bitInstalled {
-    $registryPath = 'HKLM:\SOFTWARE\WOW6432Node\Google\Update\ClientState\'
-    if (!(Test-Path $registryPath)) { return }
+    $registryPath = 'HKLM:\SOFTWARE\WOW6432Node\Google\Update\ClientState\*'
+    # We also return nothing if the user forces 32bit installation
+    # as we don't need to make any checks in that case.
+    if (!(Test-Path $registryPath) -or $env:ChocolateyForceX86 -eq $true) { return }
 
-    gi $registryPath | % {
-        if ((Get-ItemProperty $_.pspath).ap -eq '-multi-chrome') { return $true }
+    $32bitInstalled = gi $registryPath | % {
+        if ((Get-ItemProperty $_.pspath).ap -match 'arch_x86$') { return $true }
+    }
+    if ($32bitInstalled) {
+      return $32bitInstalled
+    }
+
+    $installLocation = Get-UninstallRegistryKey 'Google Chrome' | % { $_.InstallSource }
+    if ($installLocation) {
+      return Test-Path "$installLocation\nacl_irt_x86_32.nexe"
+    } else {
+      Write-Warning "Unable to find the architecture of the installed Google Chrome application"
     }
 }
 
@@ -11,7 +23,7 @@ function Get-ChromeVersion() {
     $root   = 'HKLM:\SOFTWARE\Google\Update\Clients'
     $root64 = 'HKLM:\SOFTWARE\Wow6432Node\Google\Update\Clients'
     foreach ($r in $root,$root64) {
-        $gcb = gci $r -ea 0 | ? { (gp $_.PSPath) -match 'Google Chrome binaries' }
+        $gcb = gci $r -ea 0 | ? { (gp $_.PSPath).name -eq 'Google Chrome' }
         if ($gcb) { return $gcb.GetValue('pv') }
     }
 }

--- a/automatic/GoogleChrome/update.ps1
+++ b/automatic/GoogleChrome/update.ps1
@@ -2,7 +2,7 @@ import-module au
 . "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
 $releases = 'http://omahaproxy.appspot.com/all?os=win&amp;channel=stable'
-$paddedUnderVersion = '56.0.2925'
+$paddedUnderVersion = '57.0.2988'
 
 function global:au_SearchReplace {
    @{
@@ -11,6 +11,7 @@ function global:au_SearchReplace {
             "(?i)(^\s*url64bit\s*=\s*)('.*')"   = "`$1'$($Latest.URL64)'"
             "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
             "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+            "(?i)(^[$]version\s*=\s*)('.*')"    = "`$1'$($Latest.RemoteVersion)'"
         }
     }
 }
@@ -23,6 +24,7 @@ function global:au_GetLatest {
         URL32 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'
         URL64 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
         Version = Get-Padded-Version -Version $version -OnlyBelowVersion $paddedUnderVersion -RevisionLength 5
+        RemoteVersion = $version
     }
 }
 

--- a/automatic/GoogleChrome/update.ps1
+++ b/automatic/GoogleChrome/update.ps1
@@ -1,31 +1,36 @@
-import-module au
+﻿import-module au
 . "$PSScriptRoot\..\..\scripts\Get-Padded-Version.ps1"
 
 $releases = 'http://omahaproxy.appspot.com/all?os=win&amp;channel=stable'
 $paddedUnderVersion = '57.0.2988'
 
+function global:au_BeforeUpdate {
+  $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32
+  $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64
+}
+
 function global:au_SearchReplace {
-   @{
-        ".\tools\chocolateyInstall.ps1" = @{
-            "(?i)(^\s*url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
-            "(?i)(^\s*url64bit\s*=\s*)('.*')"   = "`$1'$($Latest.URL64)'"
-            "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
-            "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
-            "(?i)(^[$]version\s*=\s*)('.*')"    = "`$1'$($Latest.RemoteVersion)'"
-        }
+  @{
+    ".\tools\chocolateyInstall.ps1" = @{
+      "(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
+      "(?i)(^\s*url64bit\s*=\s*)('.*')" = "`$1'$($Latest.URL64)'"
+      "(?i)(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+      "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+      "(?i)(^[$]version\s*=\s*)('.*')" = "`$1'$($Latest.RemoteVersion)'"
     }
+  }
 }
 
 function global:au_GetLatest {
-    $release_info = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $version = $release_info | % Content | ConvertFrom-Csv | % current_version
+  $release_info = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $version = $release_info | % Content | ConvertFrom-Csv | % current_version
 
-    @{
-        URL32 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'
-        URL64 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
-        Version = Get-Padded-Version -Version $version -OnlyBelowVersion $paddedUnderVersion -RevisionLength 5
-        RemoteVersion = $version
-    }
+  @{
+    URL32 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'
+    URL64 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
+    Version = Get-Padded-Version -Version $version -OnlyBelowVersion $paddedUnderVersion -RevisionLength 5
+    RemoteVersion = $version
+  }
 }
 
-update
+update -ChecksumFor none


### PR DESCRIPTION
The registry key we previously used for detecting an already installed 32bit installation have changed.
This PR fixes that, while also providing a fallback to check if the `nacl_irt_x86_32.nexe` do exist (this only exists on 32bit installations).

The check for the currently installed version had also broken, so this is also fixed.

fixes #667 

*MERGE with `[AU googlechrome]` in the title*

/cc @majkinetor @mattheyan