### PR TITLE
Add test for the existance of explorer.exe

### DIFF
--- a/automatic/7zip.install/tools/chocolateyInstall.ps1
+++ b/automatic/7zip.install/tools/chocolateyInstall.ps1
@@ -17,7 +17,12 @@ Install-ChocolateyInstallPackage @packageArgs
 rm $toolsDir\*.exe -ea 0 -force
 
 # 7z installer may close explorer
-if (!(ps explorer -ea 0)) { start explorer.exe }
+if (!(ps explorer -ea 0)) {
+    # Only start explorer if the file exists; Server Core installs do not have it.
+    if (!(Test-Path "$env:windir\explorer.exe")) {
+        start explorer.exe
+    }
+}
 
 $installLocation = Get-AppInstallLocation $packageArgs.softwareName
 if (!$installLocation)  { Write-Warning "Can't find 7zip install location"; return }


### PR DESCRIPTION
Server Core images don't ship with explorer; this check prevents the installation failing because of that. Fixes #690 