### PR TITLE
(mkvtoolnix) update.ps1: fix version detection

### DIFF
--- a/automatic/mkvtoolnix/update.ps1
+++ b/automatic/mkvtoolnix/update.ps1
@@ -19,7 +19,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $version = $download_page.links | % { $_.href.Replace('/','') } | ? { [version]::TryParse($_, [ref]($__)) } | measure -Max | % Maximum
+    $version = $download_page.links | % { $_.href.Replace('/','') } | % -begin { $max = $null } { try { $ver = [version]$_; if($ver -gt $max) { $max = $ver } } catch {} } -end { $max }
 
     $releases = "$releases/$version/"
     $re = '^mkvtoolnix-.+\.exe$'


### PR DESCRIPTION
```
PS> '11.0.0' -gt '9.9.0'
False
PS> [version]'11.0.0' -gt [version]'9.9.0'
True
```

I'd describe myself as a novice with PS code, so this may not be an optimal or idiomatic approach. Please feel free to suggest a better alternative.