### PR TITLE
Migrated from dtgm

### DIFF
--- a/manual/vcredist2008/README.md
+++ b/manual/vcredist2008/README.md
@@ -7,5 +7,4 @@ This package installs runtime components of C Runtime (CRT), Standard C++, ATL, 
 ## Notes
 
 - This will install **both the 32 and 64 bit versions** on a 64 bit OS.  The 32 bit version will only be installed on a 32 bit OS.
-- Microsoft published: 6/7/2011
 - [Latest supported Visual C++ downloads](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)

--- a/manual/vcredist2008/README.md
+++ b/manual/vcredist2008/README.md
@@ -4,4 +4,6 @@ The Microsoft Visual C++ 2008 SP1 Redistributable Package installs runtime compo
 
 This package installs runtime components of C Runtime (CRT), Standard C++, ATL, MFC, OpenMP and MSDIA libraries. For libraries that support side-by-side deployment model (CRT, SCL, ATL, MFC, OpenMP) they are installed into the native assembly cache, also called WinSxS folder, on versions of Windows operating system that support side-by-side assemblies.
 
-This will install both the 32 and 64 bit versions on a 64 bit OS.  The 32 bit version will only be installed on a 32 bit OS.
+## Notes
+
+- This will install **both the 32 and 64 bit versions** on a 64 bit OS.  The 32 bit version will only be installed on a 32 bit OS.

--- a/manual/vcredist2008/README.md
+++ b/manual/vcredist2008/README.md
@@ -1,0 +1,7 @@
+# [vcredist2008](https://chocolatey.org/packages/vcredist2008)
+
+The Microsoft Visual C++ 2008 SP1 Redistributable Package installs runtime components of Visual C++ Libraries required to run applications developed with Visual C++ SP1 on a computer that does not have Visual C++ 2008 SP1 installed. 
+
+This package installs runtime components of C Runtime (CRT), Standard C++, ATL, MFC, OpenMP and MSDIA libraries. For libraries that support side-by-side deployment model (CRT, SCL, ATL, MFC, OpenMP) they are installed into the native assembly cache, also called WinSxS folder, on versions of Windows operating system that support side-by-side assemblies.
+
+This will install both the 32 and 64 bit versions on a 64 bit OS.  The 32 bit version will only be installed on a 32 bit OS.

--- a/manual/vcredist2008/README.md
+++ b/manual/vcredist2008/README.md
@@ -7,3 +7,5 @@ This package installs runtime components of C Runtime (CRT), Standard C++, ATL, 
 ## Notes
 
 - This will install **both the 32 and 64 bit versions** on a 64 bit OS.  The 32 bit version will only be installed on a 32 bit OS.
+- Microsoft published: 6/7/2011
+- [Latest supported Visual C++ downloads](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)

--- a/manual/vcredist2008/tools/chocolateyInstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyInstall.ps1
@@ -11,3 +11,7 @@
   ValidExitCodes= @(0,3010)  # http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
 } 
 Install-ChocolateyPackage @params
+
+# Install both 32bit and 64bit on a 64bit OS
+# If a program is compiled as x86 and the 32bit version of vcredist isn't installed, then the program would fail to start.
+if (Get-ProcessorBits 64) { $Env:chocolateyForceX86 = $true; Install-ChocolateyPackage @params }

--- a/manual/vcredist2008/tools/chocolateyInstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyInstall.ps1
@@ -1,0 +1,13 @@
+﻿$params = @{
+  PackageName   = 'vcredist2008'
+  FileType      = 'exe'
+  Url           = 'https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe'
+  Url64bit      = 'https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe'
+  Checksum      = '470640aa4bb7db8e69196b5edb0010933569e98d'
+  Checksum64    = 'a7c83077b8a28d409e36316d2d7321fa0ccdb7e8'
+  ChecksumType  = "sha1"
+  ChecksumType64= 'sha1'
+  SilentArgs    = '/Q'
+  ValidExitCodes= @(0,3010)  # http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
+} 
+Install-ChocolateyPackage @params

--- a/manual/vcredist2008/tools/chocolateyUninstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyUninstall.ps1
@@ -1,0 +1,15 @@
+﻿$packageName = 'vcredist2005'
+$packageSearch = "Microsoft Visual C++ 2008 Redistributable*"
+$installerType = 'msi'
+$silentArgs = '/quiet /qn /norestart'
+$validExitCodes = @(0,3010)  # http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
+
+Get-ItemProperty -Path @( 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+                          'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+                          'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' ) `
+                 -ErrorAction:SilentlyContinue `
+| Where-Object   {$_.DisplayName -Like $packageSearch} `
+| ForEach-Object {Uninstall-ChocolateyPackage -PackageName "$packageName" `
+                                              -FileType "$installerType" `
+                                              -SilentArgs "$($_.PSChildName) $silentArgs" `
+                                              -ValidExitCodes $validExitCodes}

--- a/manual/vcredist2008/tools/chocolateyUninstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyUninstall.ps1
@@ -1,15 +1,28 @@
-﻿$packageName = 'vcredist2005'
-$packageSearch = "Microsoft Visual C++ 2008 Redistributable*"
-$installerType = 'msi'
-$silentArgs = '/quiet /qn /norestart'
-$validExitCodes = @(0,3010)  # http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
+﻿$ErrorActionPreference = 'Stop'
 
-Get-ItemProperty -Path @( 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
-                          'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
-                          'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' ) `
-                 -ErrorAction:SilentlyContinue `
-| Where-Object   {$_.DisplayName -Like $packageSearch} `
-| ForEach-Object {Uninstall-ChocolateyPackage -PackageName "$packageName" `
-                                              -FileType "$installerType" `
-                                              -SilentArgs "$($_.PSChildName) $silentArgs" `
-                                              -ValidExitCodes $validExitCodes}
+$packageName         = 'vcredist2008'
+$softwareNamePattern = 'Microsoft Visual C++ 2008 Redistributable*'
+
+[array] $key = Get-UninstallRegistryKey $softwareNamePattern
+if ($key.Count -eq 1) {
+    $key | % {
+        $packageArgs = @{
+            packageName            = $packageName
+            silentArgs             = "/quiet /qn /norestart"
+            fileType               = 'msi'
+            validExitCodes         = @(0,3010) # http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
+            file                   = ''
+        }
+        $packageArgs.file = "$($_.UninstallString.Replace(' /x86=0', ''))"   #"C:\Program Files\OpenSSH\uninstall.exe" /x86=0
+        Uninstall-ChocolateyPackage @packageArgs
+    }
+}
+elseif ($key.Count -eq 0) {
+    Write-Warning "$packageName has already been uninstalled by other means."
+}
+elseif ($key.Count -gt 1) {
+    Write-Warning "$key.Count matches found!"
+    Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+    Write-Warning "Please alert package maintainer the following keys were matched:"
+    $key | % {Write-Warning "- $_.DisplayName"}
+}

--- a/manual/vcredist2008/tools/chocolateyUninstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyUninstall.ps1
@@ -4,7 +4,8 @@ $packageName         = 'vcredist2008'
 $softwareNamePattern = 'Microsoft Visual C++ 2008 Redistributable*'
 
 [array] $key = Get-UninstallRegistryKey $softwareNamePattern
-if ($key.Count -eq 1) {
+$cnt = if (Get-ProcessorBits 64)  {2} else {1}
+if ($key.Count -in 1,2) {
     $key | % {
         $packageArgs = @{
             packageName            = $packageName
@@ -19,7 +20,7 @@ if ($key.Count -eq 1) {
 elseif ($key.Count -eq 0) {
     Write-Warning "$packageName has already been uninstalled by other means."
 }
-elseif ($key.Count -gt 1) {
+elseif ($key.Count -gt $cnt) {
     Write-Warning "${$key.Count} matches found!"
     Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
     Write-Warning "Please alert package maintainer the following keys were matched:"

--- a/manual/vcredist2008/tools/chocolateyUninstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyUninstall.ps1
@@ -21,8 +21,8 @@ elseif ($key.Count -eq 0) {
     Write-Warning "$packageName has already been uninstalled by other means."
 }
 elseif ($key.Count -gt $cnt) {
-    Write-Warning "${$key.Count} matches found!"
+    Write-Warning "$($key.Count) matches found!"
     Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
     Write-Warning "Please alert package maintainer the following keys were matched:"
-    $key | % {Write-Warning "- ${$_.DisplayName}"}
+    $key | % {Write-Warning "- $($_.DisplayName)"}
 }

--- a/manual/vcredist2008/tools/chocolateyUninstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyUninstall.ps1
@@ -11,9 +11,8 @@ if ($key.Count -eq 1) {
             silentArgs             = "/quiet /qn /norestart"
             fileType               = 'msi'
             validExitCodes         = @(0,3010) # http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
-            file                   = ''
+            file                   = "$($_.UninstallString.Replace(' /x86=0', ''))"   #"C:\Program Files\OpenSSH\uninstall.exe" /x86=0
         }
-        $packageArgs.file = "$($_.UninstallString.Replace(' /x86=0', ''))"   #"C:\Program Files\OpenSSH\uninstall.exe" /x86=0
         Uninstall-ChocolateyPackage @packageArgs
     }
 }
@@ -21,8 +20,8 @@ elseif ($key.Count -eq 0) {
     Write-Warning "$packageName has already been uninstalled by other means."
 }
 elseif ($key.Count -gt 1) {
-    Write-Warning "$key.Count matches found!"
+    Write-Warning "${$key.Count} matches found!"
     Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
     Write-Warning "Please alert package maintainer the following keys were matched:"
-    $key | % {Write-Warning "- $_.DisplayName"}
+    $key | % {Write-Warning "- ${$_.DisplayName}"}
 }

--- a/manual/vcredist2008/update.ps1
+++ b/manual/vcredist2008/update.ps1
@@ -1,0 +1,2 @@
+. "$PSScriptRoot\..\..\scripts\Set-DescriptionFromReadme.ps1"
+Set-DescriptionFromReadme -SkipFirst 1

--- a/manual/vcredist2008/vcredist2008.nuspec
+++ b/manual/vcredist2008/vcredist2008.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+
+<!-- IconUrl: Skip check -->
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>vcredist2008</id>
+    <version>9.0.30729.6161</version>
+    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/manual/vcredist2008</packageSourceUrl>
+    <owners>chocolatey, dtgm</owners>
+    <title>Microsoft Visual C++ 2008 SP1 Redistributable Package</title>
+    <authors>Microsoft</authors>
+    <projectUrl>https://www.microsoft.com/download/details.aspx?id=26368</projectUrl>
+    <copyright>http://www.microsoft.com/about/legal/en/us/IntellectualProperty/Copyright/Default.aspx</copyright>
+    <licenseUrl>http://msdn.microsoft.com/en-US/cc300389.aspx</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <docsUrl>https://msdn.microsoft.com/library/jj620919.aspx</docsUrl>
+    <bugTrackerUrl>https://visualstudio.uservoice.com/forums/121579-visual-studio</bugTrackerUrl>
+    <tags>microsoft visual c++ redistributable 2017 admin</tags>
+    <summary>Runtime components of C Runtime (CRT), Standard C++, ATL, MFC, OpenMP and MSDIA libraries. For libraries that support side-by-side deployment model (CRT, SCL, ATL, MFC, OpenMP)</summary>
+    <description> </description>
+  </metadata>
+</package>

--- a/manual/vcredist2008/vcredist2008.nuspec
+++ b/manual/vcredist2008/vcredist2008.nuspec
@@ -19,5 +19,14 @@
     <tags>microsoft visual c++ redistributable 2017 admin</tags>
     <summary>Runtime components of C Runtime (CRT), Standard C++, ATL, MFC, OpenMP and MSDIA libraries. For libraries that support side-by-side deployment model (CRT, SCL, ATL, MFC, OpenMP)</summary>
     <description> </description>
+    <releaseNotes>
+    - MFC Security Update: A security issue has been identified leading to MFC application vulnerability in DLL planting due to MFC not specifying the full path to system/localization DLLs. You can protect your computer by installing this update from Microsoft. After you install this item, you may have to restart.
+    - KB Article: [KB2538243](http://support.microsoft.com/kb/2538243)
+    - Security bulletin: [MS11-025](http://technet.microsoft.com/security/Bulletin/MS11-025)
+    - Microsoft published: 6/7/2011
+    </releaseNotes>
   </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
 </package>


### PR DESCRIPTION
closes #724

- Modernized
- Added README.md
- I didn't understand why double install in [original package](https://chocolatey.org/packages/vcredist2008) so I removed it.
- PR for removal on dtgm repo: https://github.com/dtgm/chocolatey-packages/pull/300 (looks like automatic but it probably doesn't work).

Push is required to point package to this repository but other changes are cosmetic.
