### PR TITLE
(ruby) Ensure unattended

### DIFF
--- a/automatic/ruby/tools/chocolateyInstall.ps1
+++ b/automatic/ruby/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
   fileType       = 'exe'
   file           = gi "$toolsDir\*_x32.exe"
   file64         = gi "$toolsDir\*_x64.exe"
-  silentArgs     = '/verysilent /dir="{0}" /tasks="assocfiles,modpath"' -f $installDir
+  silentArgs     = '/verysilent /dir="{0}" /tasks="assocfiles, modpath, noridkinstall"' -f $installDir
   validExitCodes = @(0)
   softwareName   = 'ruby *'
 }


### PR DESCRIPTION
Ruby now uses RubyInstaller2 as of 2.4, which means a new
way of installing and setting up the DevKit, which is built into
Ruby instead of having to install separately. Unfortunately 
that also means some new changes, as a window pops up 
after the install (thankfully in a non-blocking way) to ask the
user to select how they would like to have the devkit install
proceed. The switch `noridkinstall` prevents that from 
happening. As of any version of Ruby past 2.4.1-1, this will
be the default as well, but it's better to be explicit about 
specifying this behavior.

https://github.com/oneclick/rubyinstaller2/issues/43
https://github.com/oneclick/rubyinstaller2/wiki/FAQ#user-content-silent-install

Fixes #742