### PR TITLE
(sysinternals) Last updated date builds from HTTP header

### DIFF
--- a/automatic/sysinternals/update.ps1
+++ b/automatic/sysinternals/update.ps1
@@ -31,8 +31,16 @@ function global:au_GetLatest {
     $url     = $download_page.links | ? href -match $re | select -First 1 -Expand href
     $urlNano = $download_page.links | ? href -match 'Nano\.zip$' | select -First 1 -Expand href
 
-    $updated = $download_page.Content -split "`n" | sls '(?<=Updated: )[^/<>]+' | % Matches | % Value
-    $updated = [datetime]::ParseExact($updated, 'MMMM dd, yyyy', [cultureinfo]::InstalledUICulture)
+    # Previous version of this script extracted $updated from the html page content:
+    # $updated = $download_page.Content -split "`n" | sls '(?<=Updated: )[^/<>]+' | % Matches | % Value
+    # $updated = [datetime]::ParseExact($updated, 'MMMM dd, yyyy', [cultureinfo]::InstalledUICulture)
+    #
+    # But sometimes Microsoft publishes new versions of SysinternalsSuite.zip without changing html.
+    # After PR #760 (https://github.com/chocolatey/chocolatey-coreteampackages/pull/760) $updated fills from 'Last-Modified' HTTP header.
+    $lastModified = (Invoke-WebRequest -Uri $url -Method HEAD).Headers['Last-Modified'] -as [DateTime]
+    $lastModifiedNano = (Invoke-WebRequest -Uri $urlNano -Method HEAD).Headers['Last-Modified'] -as [DateTime]
+    $updated = If ($lastModified -gt $lastModifiedNano) {$lastModified} Else {$lastModifiedNano}
+
     @{
         Version  = $updated.ToString("yyyy.M.d")
         URL32    = $url


### PR DESCRIPTION
As already mentioned in #756 and [here](https://chocolatey.org/packages/sysinternals#comment-3359914265), Microsoft updated archives and forgot to change html:
<img width="284" alt="updated" src="https://user-images.githubusercontent.com/2307197/27136114-14b4c744-5123-11e7-97c1-cedf5a3695ef.png">

But http server didn't forget: `Last-Modified` HTTP header in response is correct:
```
Last-Modified: Wed, 14 Jun 2017 00:07:01 GMT
```

In this PR I fixed `update.ps1` to use `Last-Modified` HTTP header instead of `Updated` text.