### PR TITLE
(apache-httpd) add missing file64 and dependency for chocolatey

### DIFF
--- a/automatic/apache-httpd/apache-httpd.nuspec
+++ b/automatic/apache-httpd/apache-httpd.nuspec
@@ -41,6 +41,7 @@ The Apache HTTP Server is a project of The Apache Software Foundation.
     <dependencies>
        <dependency id="vcredist2015" />
        <dependency id="chocolatey-core.extension" />
+       <dependency id="chocolatey" version="0.10.5" />
    </dependencies>
   </metadata>
   <files>

--- a/automatic/apache-httpd/tools/helpers.ps1
+++ b/automatic/apache-httpd/tools/helpers.ps1
@@ -52,6 +52,7 @@ function Install-Apache {
 
     Get-ChocolateyUnzip `
         -file $arguments.file `
+        -file64 $arguments.file64 `
         -destination $arguments.destination
 
     Set-ApacheConfig $arguments


### PR DESCRIPTION
I add -file64 $arguments.file64 to the helpers.ps1 and a dependency on chocolatey version 0.10.5 for apache-httpd package