### PR TITLE
(openssl.light) set path variable in install

### DIFF
--- a/automatic/openssl.light/tools/chocolateyInstall.ps1
+++ b/automatic/openssl.light/tools/chocolateyInstall.ps1
@@ -4,10 +4,15 @@ $toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $pp = Get-PackageParameters
 $silentArgs = '/silent','/sp-','/suppressmsgboxes'
-if ($pp.InstallDir) { $silentArgs += @("/DIR=`"$($pp.InstallDir)`"") }
-else {
-  $silentArgs += @("/DIR=`"$env:ProgramFiles\OpenSSL`"")
+
+if ($pp.InstallDir) {
+  $dir = $pp.InstallDir 
 }
+else {
+  $dir = "$($env:ProgramFiles)\OpenSSL"
+}
+
+$silentArgs += @("/DIR=`"$dir`"")
 
 $packageArgs = @{
   packageName    = 'OpenSSL.Light'
@@ -20,5 +25,7 @@ $packageArgs = @{
 }
 
 Install-ChocolateyInstallPackage @packageArgs
+$binPath = "$($dir)\bin" 
+Install-ChocolateyPath -PathToInstall $binPath 
 
 Remove-Item -Force -ea 0 "$toolsPath\*.exe","$toolsPath\*.ignore"

--- a/automatic/openssl.light/tools/chocolateyInstall.ps1
+++ b/automatic/openssl.light/tools/chocolateyInstall.ps1
@@ -4,15 +4,10 @@ $toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $pp = Get-PackageParameters
 $silentArgs = '/silent','/sp-','/suppressmsgboxes'
-
-if ($pp.InstallDir) {
-  $dir = $pp.InstallDir 
-}
+if ($pp.InstallDir) { $silentArgs += @("/DIR=`"$($pp.InstallDir)`"") }
 else {
-  $dir = "$($env:ProgramFiles)\OpenSSL"
+  $silentArgs += @("/DIR=`"$env:ProgramFiles\OpenSSL`"")
 }
-
-$silentArgs += @("/DIR=`"$dir`"")
 
 $packageArgs = @{
   packageName    = 'OpenSSL.Light'
@@ -25,7 +20,15 @@ $packageArgs = @{
 }
 
 Install-ChocolateyInstallPackage @packageArgs
-$binPath = "$($dir)\bin" 
-Install-ChocolateyPath -PathToInstall $binPath 
+
+$installLocation = Get-AppInstallLocation $packageArgs.softwareName
+$binPath = "$($installLocation)\bin" 
+
+if(Test-Path $installLocation ) {
+  Install-ChocolateyPath -PathToInstall $binPath -PathType Machine 
+}
+else {
+  Write-Warning "Could not add install directory to path"
+}
 
 Remove-Item -Force -ea 0 "$toolsPath\*.exe","$toolsPath\*.ignore"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Added a Install-ChocolateyPath to add a path entry for the openssl bin directory

## Motivation and Context
fixes #773

## How Has this Been Tested?
windows 7 testing using choco install -fdv .\openssl.light.nuspec

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [x] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/.github/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
