### PR TITLE
(cygwin) The check for the architecture is reversed

### DIFF
--- a/automatic/cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/cygwin/tools/chocolateyInstall.ps1
@@ -49,5 +49,5 @@ Install-ChocolateyInstallPackage @packageArgs
 Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
-$setup_path = if (Get-ProcessorBits 64 -and $env:ChocolateyForceX86 -ne $true) { $packageArgs.file } else { $packageArgs.file64 }
+$setup_path = if (Get-ProcessorBits 32 -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
 mv $setup_path $cygwin_root\cygwinsetup.exe -Force


### PR DESCRIPTION
## Description
Reversed the check condition for the architecture (32/64 bit).

## Motivation and Context
The package is installing the 32bit binary in 64bit platforms and vice versa.

## How Has this Been Tested?
Simple condition negation, tested on command line.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [ ] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
