### PR TITLE
(GH-790) Support Visual Studio Code 64-Bit version

### DIFF
--- a/automatic/visualstudiocode/update.ps1
+++ b/automatic/visualstudiocode/update.ps1
@@ -1,7 +1,8 @@
 import-module au
 import-module "$PSScriptRoot/../../extensions/chocolatey-core.extension/extensions/chocolatey-core.psm1"
 
-$releases = 'https://vscode-update.azurewebsites.net/api/update/win32/stable/VERSION'
+$releases32 = 'https://vscode-update.azurewebsites.net/api/update/win32/stable/VERSION'
+$releases64 = 'https://vscode-update.azurewebsites.net/api/update/win32-x64/stable/VERSION'
 
 function global:au_SearchReplace {
     @{
@@ -16,12 +17,17 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $json = Invoke-WebRequest -UseBasicParsing -Uri $releases | ConvertFrom-Json
+    $json32 = Invoke-WebRequest -UseBasicParsing -Uri $releases32 | ConvertFrom-Json
+    $json64 = Invoke-WebRequest -UseBasicParsing -Uri $releases64 | ConvertFrom-Json
+
+    if ($json32.productVersion -ne $json64.productVersion) {
+        throw "Different versions for 32-Bit and 64-Bit detected."
+    }
 
     @{
-        Version   = $json.productVersion
-        URL32     = $json.Url
-        URL64     = $json.Url
+        Version   = $json32.productVersion
+        URL32     = $json32.Url
+        URL64     = $json64.Url
     }
 }
 


### PR DESCRIPTION
## Description
Support for 64-Bit versions of Visual Studio Code.

## Motivation and Context
The Visual Studio Code package should install the 64-bit version on 64-bit operating systems which will be [available starting from 1.15](https://code.visualstudio.com/updates/v1_14#_windows-64-bit-insiders)

Fixes #790 

## How Has this Been Tested?
Tested locally with updating to 1.14.2

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [x] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
