### PR TITLE
(seafile-client) change URL from bintray to seadrive.org

### DIFF
--- a/automatic/seafile-client/tools/chocolateyInstall.ps1
+++ b/automatic/seafile-client/tools/chocolateyInstall.ps1
@@ -7,7 +7,7 @@ $packageArgs = @{
 
   checksum     = 'e76626742272ac04060d002b7f83f5f25d2f704723b6192751e6ac104140b5e1'
   checksumType = 'sha256'
-  url          = 'https://bintray.com/artifact/download/seafile-org/seafile/seafile-6.0.7-en.msi'
+  url          = 'https://download.seadrive.org/seafile-6.0.7-en.msi'
 
   silentArgs   = '/passive'
   validExitCodes = @(0)


### PR DESCRIPTION
## Description

The bintray.com URL never worked for me.. don't why that was or is. Also I'm not sure how or if `update.ps1` would modify `tools/chocolateyInstall.ps1`. 
I checked the hash, it's still the same file - you never know.

## Motivation and Context

The package was broken.

## How Has this Been Tested?

`choco install seafile-client -s .`