### PR TITLE
(virtualbox) Problem with Entrust cert store with roamin user

### DIFF
--- a/automatic/virtualbox/tools/chocolateyInstall.ps1
+++ b/automatic/virtualbox/tools/chocolateyInstall.ps1
@@ -3,7 +3,7 @@
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 . $toolsPath\helpers.ps1
 
-$cert = ls cert: -Recurse | ? { $_.Thumbprint -eq 'a88fd9bdaa06bc0f3c491ba51e231be35f8d1ad5' }
+$cert = ls Cert:\CurrentUser\TrustedPublisher -Recurse | ? { $_.Thumbprint -eq 'a88fd9bdaa06bc0f3c491ba51e231be35f8d1ad5' }
 if (!$cert) {
     $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
     Start-ChocolateyProcessAsAdmin "certutil -addstore 'TrustedPublisher' '$toolsPath\oracle.cer'"


### PR DESCRIPTION
```
λ  ls Cert:\CurrentUser\TrustedPublisher -Recurse


   PSParentPath: Microsoft.PowerShell.Security\Certificate::CurrentUser\TrustedPublisher

Thumbprint                                Subject
----------                                -------
E9A7896217C146DF9FC1F4B64D53B5AC7CF95DD6  CN=Arduino srl, O=Arduino srl, L=Scarmagno, S=Torino, C=IT
B9EAA034C821C159B05D3521BCF7FEB796EBD6FF  CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
AF124C200336F4248B03DEDCDA1AE51067F8DAF4  CN=Arduino LLC, O=Arduino LLC, L=Somerville, S=Massachusetts, C=US
A18084D4ADB468E20B5407ADFED44977B12D50EA  CN=U531296, OU=AFT-I, OU=AFT, OU=Users, OU=GDN, DC=ent, DC=off, DC=lsy, DC=pl
6AE09248DA3E30725EF8D91D5A985EE0F6150A18  E=support@adafruit.com, CN=Adafruit Industries, O=Adafruit Industries, L=New York, S=NY, C=US
60E49D63E304B9E1D14860B346462713E8F1C1BE  CN=Intel Wireless Display
5BDEFE580A816661CDB57A57107BF4187486EFCC  CN=Oracle Corporation, O=Oracle Corporation, L=Redwood Shores, S=California, C=US
A18084D4ADB468E20B5407ADFED44977B12D50EA  CN=U531296, OU=AFT-I, OU=AFT, OU=Users, OU=GDN, DC=ent, DC=off, DC=lsy, DC=pl


\currentuser\Entrust Cache
λ  ls cert:
ls : The request is not supported
At line:1 char:1
+ ls cert:
+ ~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Get-ChildItem], Win32Exception
    + FullyQualifiedErrorId : System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.GetChildItemCommand

\currentuser\Entrust Cache

```
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
With Entrust software (sigining emails) and store type as roamin user im not able to run "ls cert:" command successfully. However the cert for oracle is being installed in the exact location, why dont we just check this store.

## Motivation and Context
Cannot install VirtualBox, I think above  can be solution for this.

## How Has this Been Tested?
Test above, no test with installation virtualbox though.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [ ] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package have not been migrated from another location -->
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [ ] Issue 1 link
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/wiki/Package-migration-process) have been followed
