### PR TITLE
(sourcetree) Remove mention of SourceTree Auto Update Deactivation package

### DIFF
--- a/automatic/sourcetree/sourcetree.nuspec
+++ b/automatic/sourcetree/sourcetree.nuspec
@@ -35,8 +35,6 @@ SourceTree simplifies how you interact with your Git and Mercurial repositories 
 
 This package installs the current version in General Availability.
 For details on SourceTrees release process see [this blog post](https://blog.sourcetreeapp.com/2016/03/31/sourcetree-beta-program-a-look-behind-the-curtains/).
-
-For disabling the auto-update functionality of SourceTree see the [SourceTree Auto Update Deactivation package](https://chocolatey.org/packages/sourcetree-disableautoupdate).
 </description>
     <releaseNotes>https://www.sourcetreeapp.com/update/WindowsReleaseNotes.html</releaseNotes>
     <tags>git mercurial client admin freeware cross-platform</tags>


### PR DESCRIPTION
## Description
Remove mention of SourceTree Auto Update Deactivation package since it only works for version 1.x

## Motivation and Context
The SourceTree AutoUpdate Deactivation package only works for SourceTree 1.x. Related to #776 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
- [ ] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [x] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [ ] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).