### PR TITLE
(visualstudiocode) Install 32-bit version on 64-bit systems if already a 32-bit version is installed

### DIFF
--- a/automatic/visualstudiocode/Tools/ChocolateyInstall.ps1
+++ b/automatic/visualstudiocode/Tools/ChocolateyInstall.ps1
@@ -11,7 +11,6 @@ Write-Host "Merge Tasks: "
 Write-Host "$mergeTasks"
 
 $packageName = 'visualstudiocode'
-$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url32 = 'https://az764295.vo.msecnd.net/stable/8b95971d8cccd3afd86b35d4a0e098c189294ff2/VSCodeSetup-ia32-1.15.0.exe'
 $url64 = 'https://az764295.vo.msecnd.net/stable/8b95971d8cccd3afd86b35d4a0e098c189294ff2/VSCodeSetup-x64-1.15.0.exe'
 $checksum32 = '9ee938c5f695fd54a06f9a48122d409f5a12d2039f63741c82d58314f1da89d6'
@@ -19,7 +18,6 @@ $checksum64 = '0c77cdb1c472a4dcbedc39d704ad79248997a66450083f3a1e48dd070b37f439'
 
 $packageArgs = @{
   packageName = $packageName
-  unzipLocation = $toolsDir
   fileType = 'EXE'
   url = $url32
   url64bit = $url64

--- a/automatic/visualstudiocode/Tools/helpers.ps1
+++ b/automatic/visualstudiocode/Tools/helpers.ps1
@@ -1,0 +1,25 @@
+﻿function Get-32BitInstalledOn64BitSystem() {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$product
+  )
+  $systemIs64bit = Get-ProcessorBits 64
+
+  if (-Not $systemIs64bit) {
+    return $false
+  }
+
+  $registryPaths = @(
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall'
+    'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+  )
+
+  $installedVersions = Get-ChildItem $registryPaths | Get-ItemProperty |Where-Object { $_.DisplayName -match "$product" }
+
+  if (
+    $installedVersions.InstallLocation -match 'x86' `
+    -and $systemIs64bit
+  ) {
+    return $true
+  }
+}


### PR DESCRIPTION
## Description
Install 32-bit version on 64-bit systems if already a 32-bit version is installed

## Motivation and Context
Fixes #813 

## How Has this Been Tested?
Tested updating from 1.14.2 to 1.15 on a 64-bit system and clean installation of 1.15 on a 64-bit system

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [x] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).