### PR TITLE
(tor-browser) Set NTFS modify file permissions

### DIFF
--- a/automatic/tor-browser/tools/chocolateyInstall.ps1
+++ b/automatic/tor-browser/tools/chocolateyInstall.ps1
@@ -35,3 +35,10 @@ Install-ChocolateyShortcut `
   -ShortcutFilePath "$desktop\Tor Browser.lnk" `
   -TargetPath "$toolsDir\tor-browser\Browser\firefox.exe" `
   -WorkingDirectory "$toolsDir\tor-browser\Browser"
+
+# set NTFS modify file permissions to $toolsDir\tor-browser\ for user account that installed the package
+$WhoAmI=whoami
+$Acl = Get-Acl "$toolsDir\tor-browser"
+$Ar = New-Object  system.security.accesscontrol.filesystemaccessrule($WhoAmI,"Modify","Allow")
+$Acl.SetAccessRule($Ar)
+Set-Acl "$toolsDir\tor-browser" $Acl


### PR DESCRIPTION
Post install of tor-browser, when trying to run it gives the error:
(title) Tor Browser profile Problem
(text) Tor browser does not have permission to access the profile. Please adjust your file system permissions and try again.

Expected Behavior

It should have permissions to run for at least the user account that installed the package.

Current Behavior

Package installer account does not have permission to run the program and files need to manually have permissions changed to

Possible Solution

add this to end of install script:

set NTFS modify file permissions to $toolsDir\tor-browser\ for user account that installed the package

$WhoAmI=whoami
$Acl = Get-Acl "$toolsDir\tor-browser"
$Ar = New-Object system.security.accesscontrol.filesystemaccessrule($WhoAmI,"Modify","Allow")
$Acl.SetAccessRule($Ar)
Set-Acl "$toolsDir\tor-browser" $Acl

(I forked it but not sure how to submit/push it back)!

Fixes #831