### PR TITLE
Add exit code 1603

### DIFF
--- a/automatic/putty.install/tools/chocolateyInstall.ps1
+++ b/automatic/putty.install/tools/chocolateyInstall.ps1
@@ -9,7 +9,7 @@ $packageArgs = @{
     File           = "$toolsPath\putty-0.70-installer.msi"
     File64         = "$toolsPath\putty-64bit-0.70-installer.msi"
     SilentArgs     = "/quiet"
-    ValidExitCodes = @(0)
+    ValidExitCodes = @(0,1603)
 }
 Install-ChocolateyInstallPackage @packageArgs
 


### PR DESCRIPTION
## Description
Added valid exit code 1603 as per #849 - 1603 is a common exit code used by the MSI installer but it still installs the package.

## Motivation and Context
Resolves issue #849 

## How Has this Been Tested?
It's not been tested in this installer but has in others.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [ ] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).