### PR TITLE
Fix wrong apache-http dependency

### DIFF
--- a/automatic/apache-httpd/apache-httpd.nuspec
+++ b/automatic/apache-httpd/apache-httpd.nuspec
@@ -40,7 +40,7 @@ The Apache HTTP Server is a project of The Apache Software Foundation.
 ]]></description>
     <tags>apache httpd webserver admin</tags>
     <dependencies>
-       <dependency id="vcredist2015" />
+       <dependency id="vcredist2012" />
        <dependency id="chocolatey-core.extension" />
        <dependency id="chocolatey" version="0.10.5" />
    </dependencies>


### PR DESCRIPTION
I just installed apache-http with DSC extension on several azure machines with windows server 2016.

http.exe was complaining about a missing dll. I have seen that the package depends on the MSVCR 2015 but it should be 2012.

<dependency id="vcredist2015" />
As a workaround I installed the 2012 and apache installed succesfully.