### PR TITLE
(paint.net) Update dependency to .NET 4.7

### DIFF
--- a/automatic/paint.net/paint.net.nuspec
+++ b/automatic/paint.net/paint.net.nuspec
@@ -40,7 +40,7 @@ An active and growing online community provides friendly help, tutorials, and pl
     <releaseNotes>https://www.getpaint.net/roadmap.html</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="dotnet4.6.1" version="4.6.01055.20161213" />
+      <dependency id="dotnet4.7" version="4.7.2053.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Description
Starting with 4.0.20 Paint.NET requires .NET 4.7. 

## Motivation and Context
See announcement here https://blog.getpaint.net/2017/10/23/paint-net-4-0-20-and-net-4-7/

## How Has this Been Tested?
Not tested since Paint.NET 4.0.20 is not released yet. But dependency should be there already when it will be released.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [x] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
