### PR TITLE
(mkdocs*) added proxy handling

### DIFF
--- a/automatic/mkdocs-material/mkdocs-material.nuspec
+++ b/automatic/mkdocs-material/mkdocs-material.nuspec
@@ -31,6 +31,7 @@ Material is a theme for [MkDocs](http://www.mkdocs.org/), an excellent static si
     <tags>mkdocs markdown documentation material foss cross-platform cli</tags>
     <releaseNotes>https://github.com/squidfunk/mkdocs-material/blob/master/CHANGELOG</releaseNotes>
     <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.3.3" />
       <dependency id="MkDocs" version="0.17.1" />
     </dependencies>
   </metadata>

--- a/automatic/mkdocs-material/tools/ChocolateyInstall.ps1
+++ b/automatic/mkdocs-material/tools/ChocolateyInstall.ps1
@@ -2,4 +2,9 @@
 
 $version = '2.0.4'
 
+$proxy = Get-EffectiveProxy
+if ($proxy) {
+  Write-Host "Setting CLI proxy: $proxy"
+  $env:http_proxy = $env:https_proxy = $proxy
+}
 python -m pip install mkdocs-material==$version

--- a/automatic/mkdocs/mkdocs.nuspec
+++ b/automatic/mkdocs/mkdocs.nuspec
@@ -30,6 +30,7 @@ MkDocs is a fast, simple and downright gorgeous static site generator that's gea
     <tags>mkdocs markdown documentation foss cross-platform cli</tags>
     <releaseNotes>http://www.mkdocs.org/about/release-notes/</releaseNotes>
     <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.3.3" />
       <dependency id="Python" version="2.6" />
     </dependencies>
   </metadata>

--- a/automatic/mkdocs/tools/ChocolateyInstall.ps1
+++ b/automatic/mkdocs/tools/ChocolateyInstall.ps1
@@ -2,4 +2,9 @@
 
 $version = '0.17.1'
 
+$proxy = Get-EffectiveProxy
+if ($proxy) {
+  Write-Host "Setting CLI proxy: $proxy"
+  $env:http_proxy = $env:https_proxy = $proxy
+}
 python -m pip install mkdocs==$version


### PR DESCRIPTION
It doesn't work behind the proxy:

```
mkdocs-material v2.0.4 [Approved]
mkdocs-material package files upgrade completed. Performing other installation steps.
Collecting mkdocs-material==2.0.4
  Retrying (Retry(total=4, connect=None, read=None, redirect=None)) after connection broken by 'NewConnectionError('<pip._vendor.requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x00000274174F07B8>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',)': /simple/mkdocs-material/
```

With CLI proxy:
```
> proxyc -FromSystem
$Env:ftp_proxy   = 'http://10.35.9.55:8080'
$Env:http_proxy  = 'http://10.35.9.55:8080'
$Env:https_proxy = 'http://10.35.9.55:8080'
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------5 LEC 128  17-11-07 08.35.28  D:\work\website\branches\next\_preview\output (admin)
> cup mkdocs-material
Chocolatey v0.10.8
[Pending] Removing incomplete install for 'mkdocs-material'
Upgrading the following packages:
mkdocs-material
By upgrading you accept licenses for the packages.
mkdocs-material is not installed. Installing...

mkdocs-material v2.0.4 [Approved]
mkdocs-material package files upgrade completed. Performing other installation steps.
Collecting mkdocs-material==2.0.4
  Downloading mkdocs_material-2.0.4-py2.py3-none-any.whl (119kB)
Requirement already satisfied: pymdown-extensions>=3.4 in c:\python36\lib\site-packages (from mkdocs-material==2.0.4)
Requirement already satisfied: mkdocs>=0.17.1 in c:\python36\lib\site-packages (from mkdocs-material==2.0.4)
Requirement already satisfied: Pygments>=2.2 in c:\python36\lib\site-packages (from mkdocs-material==2.0.4)
Requirement already satisfied: Markdown<3,>=2.6.0 in c:\python36\lib\site-packages (from pymdown-extensions>=3.4->mkdocs-material==2.0.4)
Requirement already satisfied: PyYAML>=3.10 in c:\python36\lib\site-packages (from mkdocs>=0.17.1->mkdocs-material==2.0.4)
Requirement already satisfied: tornado>=4.1 in c:\python36\lib\site-packages (from mkdocs>=0.17.1->mkdocs-material==2.0.4)
Requirement already satisfied: click>=3.3 in c:\python36\lib\site-packages (from mkdocs>=0.17.1->mkdocs-material==2.0.4)
Requirement already satisfied: livereload>=2.5.1 in c:\python36\lib\site-packages (from mkdocs>=0.17.1->mkdocs-material==2.0.4)
Requirement already satisfied: Jinja2>=2.7.1 in c:\python36\lib\site-packages (from mkdocs>=0.17.1->mkdocs-material==2.0.4)
Requirement already satisfied: six in c:\python36\lib\site-packages (from livereload>=2.5.1->mkdocs>=0.17.1->mkdocs-material==2.0.4)
Requirement already satisfied: MarkupSafe>=0.23 in c:\python36\lib\site-packages (from Jinja2>=2.7.1->mkdocs>=0.17.1->mkdocs-material==2.0.4)
Installing collected packages: mkdocs-material
  Found existing installation: mkdocs-material 2.0.2
    Uninstalling mkdocs-material-2.0.2:
      Successfully uninstalled mkdocs-material-2.0.2
Successfully installed mkdocs-material-2.0.4
 The upgrade of mkdocs-material was successful.
  Software install location not explicitly set, could be in package or
  default install location if installer.

Chocolatey upgraded 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```