### PR TITLE
(opera) don't create desktop shortcut or pin to taskbar

### DIFF
--- a/automatic/opera/tools/chocolateyInstall.ps1
+++ b/automatic/opera/tools/chocolateyInstall.ps1
@@ -11,7 +11,7 @@ $packageArgs = @{
   checksum64     = '44dcef541df90b3665a88091c504e56a3594a630534ea8d0f1f76f443dd6fcba'
   checksumType   = 'sha256'
   checksumType64 = 'sha256'
-  silentArgs     = '/install /silent /launchopera 0 /setdefaultbrowser 0'
+  silentArgs     = '/install /silent /launchopera 0 /setdefaultbrowser 0 /desktopshortcut 0 /pintotaskbar 0'
   validExitCodes = @(0)
 }
 


### PR DESCRIPTION
https://chocolatey.org/packages/Opera

## Description
Added two command line arguments to the installer, one to stop it from creating the desktop shortcut, the other for pinning to the taskbar.

## Motivation and Context
By default, the opera installer pins itself to the Windows Taskbar. This goes against the principles of how the taskbar should be used - Programs shouldn't pin themselves to the taskbar, Users should pin Programs to the Taskbar.

A Desktop shortcut is common practice, however for it to be re-added when updating the program is overriding the user's preference - If it's not there, it's because I deleted it, so don't readd it. Not creating the desktop shortcut on initial install is a small price to pay (it's preferable to me, but that's just personal opinion)

## How Has this Been Tested?
I downloaded the 64bit installer and ran it with the silentargs.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [x] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

