### PR TITLE
Fix error "Item has already been added" on virtualbox package

### DIFF
--- a/automatic/virtualbox/update.ps1
+++ b/automatic/virtualbox/update.ps1
@@ -51,17 +51,19 @@ function global:au_GetLatest {
 
   $links = $builds_page.Links | ? href -match 'Builds_[\d_]+$' | select -expand href
 
-  $streams = @{}
-
-  $links | % {
-    $versionPart = $_ -split 'Builds_' | select -last 1 | % { $_ -replace '_','.' }
-
-    $streams.Add($versionPart, (GetLatest "https://www.virtualbox.org$_"))
-  }
+  $streams = [ordered] @{}
 
   $latest = GetLatest "https://www.virtualbox.org/wiki/Downloads"
 
   $streams.Add((Get-Version $Latest.Version).ToString(2), $latest)
+
+  $links | % {
+    $versionPart = $_ -split 'Builds_' | select -last 1 | % { $_ -replace '_','.' }
+
+    if (!$streams.Contains($versionPart)) {
+      $streams.Add($versionPart, (GetLatest "https://www.virtualbox.org$_"))
+    }
+  }
 
   return @{ Streams = $streams}
 }


### PR DESCRIPTION
Implementation of streams on virtualbox throws an error when a stream is both available on download page and old downloads page (see https://gist.github.com/choco-bot/a14b1e5bfaf70839b338eb1ab7f8226f/438b0e80e4443264f583e4ae1d781d09894e7485#errors).

While fixing this error, I'm also changing the order of streams in order to sort them from the most recent to the oldest one as recommended for packages with streams (see https://github.com/majkinetor/au#streams).