### PR TITLE
(visualstudiocode-disableautoupdate) Use correct settings entry in all cases

### DIFF
--- a/manual/visualstudiocode-disableautoupdate/tools/helpers.ps1
+++ b/manual/visualstudiocode-disableautoupdate/tools/helpers.ps1
@@ -19,7 +19,7 @@ function Set-UpdateChannel() {
 
     $storageFileContent = @"
 {
-  "updateChannel": "$UpdateChannel"
+  "update.channel": "$UpdateChannel"
 }
 "@
   } else {
@@ -35,7 +35,7 @@ function Set-UpdateChannel() {
 
     try
     {
-      $storageFileObject.updateChannel = "$UpdateChannel"
+      $storageFileObject."update.channel" = "$UpdateChannel"
       Write-Output "Updated 'update.channel' to '$UpdateChannel'."
     }
     catch

--- a/manual/visualstudiocode-disableautoupdate/visualstudiocode-disableautoupdate.nuspec
+++ b/manual/visualstudiocode-disableautoupdate/visualstudiocode-disableautoupdate.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>visualstudiocode-disableautoupdate</id>
     <title>Visual Studio Code Auto Update Deactivation</title>
-    <version>1.0.0.20170302</version>
+    <version>1.0.0.20171228</version>
     <authors>chocolatey</authors>
     <owners>chocolatey, Pascal Berger</owners>
     <projectUrl>https://github.com/chocolatey/chocolatey-coreteampackages</projectUrl>


### PR DESCRIPTION
## Description
Use correct settings entry for disabling Visual Studio Code auto update.

Should be pushed on merging

## Motivation and Context
In certain cases the wrong settings entry would be writting (`updateChannel` instead of `update.channel`)

## How Has this Been Tested?
Tested locally

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package have been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this mean usually the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this mean usually the notes in the description of a package).
- [x] All files is up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).