### PR TITLE
(git) Added ability to use Windows native SSL/TLS via package parameter

### DIFF
--- a/automatic/git.install/CHANGELOG.md
+++ b/automatic/git.install/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2018-03-15
+
+- Added `/SChannel` parameter
+
 ## 2017-06-26
 
 - Added `/NoCredentialManager` parameter

--- a/automatic/git.install/README.md
+++ b/automatic/git.install/README.md
@@ -18,6 +18,7 @@ Git for Windows focuses on offering a lightweight, native set of tools that brin
 - `/NoShellIntegration` - Disables shell integration ( _"Git GUI Here"_ and _"Git Bash Here"_ entries in context menus).
 - `/NoCredentialManager` - Disable _Git Credential Manager_ by adding `$Env:GCM_VALIDATE='false'` user environment variable.
 - `/NoGitLfs` - Disable Git LFS installation.
+- `/SChannel` - Configure Git to use the Windows native SSL/TLS implementation (SChannel) instead of OpenSSL. This aligns Git HTTPS behavior with other Windows applications and system components and increases manageability in enterprise environments.
 
 ## Notes
 

--- a/automatic/git.install/tools/helpers.ps1
+++ b/automatic/git.install/tools/helpers.ps1
@@ -21,6 +21,7 @@ function Set-InstallerRegistrySettings( [HashTable]$pp )
     if ($pp.GitAndUnixToolsOnPath) { New-ItemProperty $InstallKey -Name "$ino Path Option"          -Value "CmdTools"       -Force }
     if ($pp.WindowsTerminal)       { New-ItemProperty $InstallKey -Name "$ino Bash Terminal Option" -Value "ConHost"        -Force }
     if ($pp.NoAutoCrlf)            { New-ItemProperty $InstallKey -Name "$ino CRLF Option"          -Value "CRLFCommitAsIs" -Force }
+    if ($pp.SChannel)              { New-ItemProperty $InstallKey -Name "$ino CURL Option"          -Value "WinSSL"         -Force }
 }
 
 function Get-InstallComponents( [HashTable]$pp )

--- a/automatic/git/README.md
+++ b/automatic/git/README.md
@@ -18,6 +18,7 @@ Git for Windows focuses on offering a lightweight, native set of tools that brin
 - `/NoShellIntegration` - Disables shell integration ( _"Git GUI Here"_ and _"Git Bash Here"_ entries in context menus).
 - `/NoCredentialManager` - Disable _Git Credential Manager_ by adding `$Env:GCM_VALIDATE='false'` user environment variable.
 - `/NoGitLfs` - Disable Git LFS installation.
+- `/SChannel` - Configure Git to use the Windows native SSL/TLS implementation (SChannel) instead of OpenSSL. This aligns Git HTTPS behavior with other Windows applications and system components and increases manageability in enterprise environments.
 
 ## Notes
 


### PR DESCRIPTION
## Description
The `git` and `git.install` packages gained a new package parameter `/SChannel`, which configures Git for Windows to use the native Windows SSL/TLS library ("SChannel") instead of OpenSSL.

## Motivation and Context
This change exposes an option of the native installer.
Implements #922.

## How Has this Been Tested?
Tested as follows:
0. preparation
- cpacked both packages
- published to personal MyGet feed ([git](https://www.myget.org/feed/jberezanski-chocolateypackages-dev/package/nuget/git/2.16.2.20180315), [git.install](https://www.myget.org/feed/jberezanski-chocolateypackages-dev/package/nuget/git.install/2.16.2.20180315))
1. test of the new feature
- on a test Windows 8.1 VM installed the packages by running
````
choco install git --version 2.16.2.20180315 --source https://www.myget.org/F/jberezanski-chocolateypackages-dev/api/v2 --params "/SChannel" -ydv

````
- verified the usage of SChannel by running the following in cmd.exe in the VM:
````
set GIT_TRACE_CURL=1
git clone https://github.com/majkinetor/au.git
````
and observing log messages mentioning schannel, such as
````
Info: schannel: SSL/TLS connection with github.com port 443 (step 1/3)
````
2. test of maintaining existing default behavior
- reverted the VM to a snapshot
- installed the packages without enabling SChannel:
````
choco install git --version 2.16.2.20180315 --source https://www.myget.org/F/jberezanski-chocolateypackages-dev/api/v2 -ydv

````
- verified the usage of OpenSSL by running the following in cmd.exe in the VM:
````
set GIT_TRACE_CURL=1
git clone https://github.com/majkinetor/au.git
````
and observing lack of log messages mentioning schannel.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

