### PR TITLE
(inkscape) removes msi before upgrade to prevent 1638 error, fixes #550

### DIFF
--- a/automatic/inkscape/tools/chocolateybeforemodify.ps1
+++ b/automatic/inkscape/tools/chocolateybeforemodify.ps1
@@ -1,0 +1,7 @@
+﻿$app = Get-WmiObject -Class Win32_Product -Filter "Name Like 'Inkscape%'"
+
+if ($app) {
+  Write-Host "Inkscape already installed. Removing..."
+  $app.Uninstall()
+  Write-Host "Done. Continuing with update/uninstall..."
+}


### PR DESCRIPTION
## Description
Added a beforemodify script that checks to see if Inkscape is installed and uninstalls the msi.

## Motivation and Context
fixes #550

## How Has this Been Tested?
Installed 0.92.2 w/ beforemodify script, then did an upgrade to 0.92.3. Tested OK.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

