### PR TITLE
(sourcetree) Add dependency to .NET 4.7.1 as required by Sourcetree 2.5

### DIFF
--- a/automatic/sourcetree/sourcetree.nuspec
+++ b/automatic/sourcetree/sourcetree.nuspec
@@ -42,6 +42,9 @@ Sourcetree simplifies how you interact with your Git repositories so you can foc
 ]]></description>
     <releaseNotes>https://www.sourcetreeapp.com/update/WindowsReleaseNotes.html</releaseNotes>
     <tags>git mercurial client admin freeware cross-platform</tags>
+    <dependencies>
+      <dependency id="dotnet4.7.1" version="4.7.2558.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
## Description
Add dependency to .NET 4.7.1 as required by Sourcetree 2.5+

## Motivation and Context
Sourcetree 2.5 changed system requirements to .NET 4.7.1

## How Has this Been Tested?
Tested locally

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).