### PR TITLE
nodejs.install - Removing Performance Counters and Event Tracing

### DIFF
--- a/automatic/nodejs.install/tools/chocolateyInstall.ps1
+++ b/automatic/nodejs.install/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
   FileType       = 'msi'
   SoftwareName   = 'Node.js'
   File           = $installFile
-  SilentArgs     = "/quiet"
+  SilentArgs     = '/quiet ADDLOCAL=ALL REMOVE=NodePerfCtrSupport,NodeEtwSupport'
   ValidExitCodes = @(0)
 }
 Install-ChocolateyInstallPackage @packageArgs


### PR DESCRIPTION
Removing Performance Counters and Event Tracing features by default due to installer ending prematurely.

## Description
Changed SilentArgs during install to skip Performance Counters and Event Tracing

## Motivation and Context
Fixes installation not completing due to issue here:

https://github.com/nodejs/node/issues/4329#issuecomment-254825118

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
Packed locally and installed. Changes are minimal.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).