### PR TITLE
(Everything) Fix outdated es.exe command line tool

### DIFF
--- a/automatic/everything/update.ps1
+++ b/automatic/everything/update.ps1
@@ -21,7 +21,8 @@ function global:au_SearchReplace {
 }
 function global:au_BeforeUpdate {
     Get-RemoteFiles -Purge -NoSuffix
-    iwr 'https://www.voidtools.com/es.exe' -OutFile $PSScriptRoot\tools\es.exe
+    iwr 'https://www.voidtools.com/ES-1.1.0.9.zip' -OutFile $env:TMP\ES-1.1.0.9.zip
+    7z x $env:TMP\ES-1.1.0.9.zip es.exe -o"$PSScriptRoot\tools"
     $Latest.ChecksumEsExe = Get-FileHash $PSScriptRoot\tools\es.exe | % Hash
 }
 function global:au_GetLatest {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Fetches es.exe from zip archive referenced on https://www.voidtools.com/ru-ru/downloads/#cli, instead of old, non-updated direct url https://www.voidtools.com/es.exe

## Motivation and Context
Solves lack of [es.exe command line options](https://www.voidtools.com/support/everything/command_line_options/), such as colorized output

## How Has this Been Tested?
Tested by AU/appveyor in [my fork](https://ci.appveyor.com/project/galeksandrp/chocolatey-coreteampackages)

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)
