### PR TITLE
(opera) Parameters for disabling desktop and taskbar shortcuts

### DIFF
--- a/automatic/opera/README.md
+++ b/automatic/opera/README.md
@@ -3,3 +3,10 @@
 
 The Opera web browser makes the Web fast and fun, giving you a better web browser experience on any computer.
 
+
+## Parameters
+- `/NoDesktopShortcut` - Do not create desktop shortcut for Opera
+- `/NoTaskbarShortcut` - Do not pin Opera to taskbar
+
+These parameters can be passed to the installer with the use of `--params`.
+For example: `--params '"/NoDesktopShortcut /NoTaskbarShortcut"'`

--- a/automatic/opera/opera.nuspec
+++ b/automatic/opera/opera.nuspec
@@ -14,6 +14,12 @@
     <description><![CDATA[
 The Opera web browser makes the Web fast and fun, giving you a better web browser experience on any computer.
 
+## Parameters
+- `/NoDesktopShortcut` - Do not create desktop shortcut for Opera
+- `/NoTaskbarShortcut` - Do not pin Opera to taskbar
+These parameters can be passed to the installer with the use of `--params`.
+For example: `--params '"/NoDesktopShortcut /NoTaskbarShortcut"'`
+
 ]]></description>
     <summary>The Opera web browser makes the Web fast and fun, giving you a better web browser experience on any computer.</summary>
     <releaseNotes>https://blogs.opera.com/desktop/changelog-for-53/#b2907.88</releaseNotes>

--- a/automatic/opera/opera.nuspec
+++ b/automatic/opera/opera.nuspec
@@ -17,6 +17,7 @@ The Opera web browser makes the Web fast and fun, giving you a better web browse
 ## Parameters
 - `/NoDesktopShortcut` - Do not create desktop shortcut for Opera
 - `/NoTaskbarShortcut` - Do not pin Opera to taskbar
+
 These parameters can be passed to the installer with the use of `--params`.
 For example: `--params '"/NoDesktopShortcut /NoTaskbarShortcut"'`
 

--- a/automatic/opera/tools/chocolateyInstall.ps1
+++ b/automatic/opera/tools/chocolateyInstall.ps1
@@ -5,7 +5,7 @@ $toolsPath = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 $pp = Get-PackageParameters
 
 $parameters += if ($pp.NoDesktopShortcut)     { " /desktopshortcut 0"; Write-Host 'Desktop shortcut won\'t be created' }
-$parameters += if ($pp.NoTaskbarShortcut) { " /pintotaskbar 0"; Write-Host 'Opera won\'t be pinned to taskbar'}
+$parameters += if ($pp.NoTaskbarShortcut)     { " /pintotaskbar 0"; Write-Host 'Opera won\'t be pinned to taskbar'}
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName

--- a/automatic/opera/tools/chocolateyInstall.ps1
+++ b/automatic/opera/tools/chocolateyInstall.ps1
@@ -4,8 +4,8 @@ $toolsPath = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 
 $pp = Get-PackageParameters
 
-$parameters += if ($pp.NoDesktopShortcut)     { " /desktopshortcut 0"; Write-Host 'Desktop shortcut won\'t be created' }
-$parameters += if ($pp.NoTaskbarShortcut)     { " /pintotaskbar 0"; Write-Host 'Opera won\'t be pinned to taskbar'}
+$parameters += if ($pp.NoDesktopShortcut)     { " /desktopshortcut 0"; Write-Host "Desktop shortcut won't be created" }
+$parameters += if ($pp.NoTaskbarShortcut)     { " /pintotaskbar 0"; Write-Host "Opera won't be pinned to taskbar" }
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName

--- a/automatic/opera/tools/chocolateyInstall.ps1
+++ b/automatic/opera/tools/chocolateyInstall.ps1
@@ -2,6 +2,11 @@
 $toolsPath = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 . "$toolsPath\helpers.ps1"
 
+$pp = Get-PackageParameters
+
+$parameters += if ($pp.NoDesktopShortcut)     { " /desktopshortcut 0"; Write-Host 'Desktop shortcut won\'t be created' }
+$parameters += if ($pp.NoTaskbarShortcut) { " /pintotaskbar 0"; Write-Host 'Opera won\'t be pinned to taskbar'}
+
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
@@ -11,7 +16,7 @@ $packageArgs = @{
   checksum64     = '372b475380cdf1e401a5f61b0636d913a72f10b72e3a8531d8c305a978d9783d'
   checksumType   = 'sha256'
   checksumType64 = 'sha256'
-  silentArgs     = '/install /silent /launchopera 0 /setdefaultbrowser 0'
+  silentArgs     = '/install /silent /launchopera 0 /setdefaultbrowser 0' + $parameters
   validExitCodes = @(0)
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
I added support for two Opera installer arguments - one stops creating desktop shortcut for Opera and the other stops pinning Opera to Windows taskbar.

## Motivation and Context
This change provides better expierence for users, because you can disallow installer from creating desktop shortcut for Opera or pinning it to taskbar, so user won't need to remove shortcut by himself each time.

## How Has this Been Tested?
I packed package with `choco pack` and tested the package with `choco install opera -s . --params "/NoDesktopShortcut /NoTaskbarShortcut"` and with `choco install opera -s .` (to see, if it didn't destroy standard installation) and just in case I also tested uninstalling it.

Tested on Windows 10, version 1803

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).