### PR TITLE
pdfcreator - fix non-silent installer

### DIFF
--- a/automatic/pdfcreator/pdfcreator.nuspec
+++ b/automatic/pdfcreator/pdfcreator.nuspec
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>PDFCreator</id>
-    <version>3.2.2</version>
-    <title>PDF Creator</title>
+    <version>3.2.2.20180717</version>
+    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/pdfcreator</packageSourceUrl>
     <owners>chocolatey</owners>
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <title>PDF Creator</title>
     <authors>pdfforge</authors>
-    <licenseUrl>https://github.com/pdfforge/PDFCreator/blob/master/LICENSE</licenseUrl>
     <projectUrl>http://www.pdfforge.org/</projectUrl>
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/6e52bf3b9392bc72475a3e254eab23578ccb9d0e/icons/PDFCreator.png</iconUrl>
+    <licenseUrl>https://github.com/pdfforge/PDFCreator/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description><![CDATA[
-PDFCreator easily creates PDFs from any Windows program. Use it like a printer in Word, StarCalc or any other Windows application.
+    <projectSourceUrl>https://github.com/pdfforge/PDFCreator</projectSourceUrl>
+    <docsUrl>http://docs.pdfforge.org/pdfcreator/latest/en/</docsUrl>
+    <tags>pdfcreator pdf editor printer foss notsilent</tags>
+    <summary>PDFCreator - PDFCreator easily creates PDFs from any Windows program.</summary>
+    <description>PDFCreator easily creates PDFs from any Windows program. Use it like a printer in Word, StarCalc or any other Windows application.
 
 ## Features
 
@@ -21,15 +27,12 @@ PDFCreator easily creates PDFs from any Windows program. Use it like a printer i
 - Profiles make frequently used settings available with one click
 - Use automatic saving to have a fully automated PDF printer
 
-]]></description>
-    <summary>PDFCreator - PDFCreator easily creates PDFs from any Windows program.</summary>
-    <tags>pdf editor printer foss admin</tags>
-    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/pdfcreator</packageSourceUrl>
-	<docsUrl>http://docs.pdfforge.org/pdfcreator/latest/en/</docsUrl>
-	<projectSourceUrl>https://github.com/pdfforge/PDFCreator</projectSourceUrl>
-  <dependencies>
-    <dependency id="chocolatey-core.extension" version="1.3.3" />
-  </dependencies>
+#### Note 
+The free, PDFCreator installer is no longer silent and may open a webpage on completion.
+    </description>
+    <dependencies>
+      <dependency id="autohotkey.portable" version="1.1" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/pdfcreator/pdfcreator.nuspec
+++ b/automatic/pdfcreator/pdfcreator.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>PDFCreator</id>
-    <version>3.2.2.20180717</version>
+    <version>3.2.2.20180718</version>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/pdfcreator</packageSourceUrl>
     <owners>chocolatey</owners>
     <!-- == SOFTWARE SPECIFIC SECTION == -->

--- a/automatic/pdfcreator/pdfcreator.nuspec
+++ b/automatic/pdfcreator/pdfcreator.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>PDFCreator</id>
-    <version>3.2.2.20180718</version>
+    <version>3.2.2.20180719</version>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/pdfcreator</packageSourceUrl>
     <owners>chocolatey</owners>
     <!-- == SOFTWARE SPECIFIC SECTION == -->
@@ -31,6 +31,7 @@
 The free, PDFCreator installer is no longer silent and may open a webpage on completion.
     </description>
     <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.3.3" />
       <dependency id="autohotkey.portable" version="1.1" />
     </dependencies>
   </metadata>

--- a/automatic/pdfcreator/tools/chocolateyInstall.ps1
+++ b/automatic/pdfcreator/tools/chocolateyInstall.ps1
@@ -45,12 +45,13 @@ catch {
 
 # silent install requires AutoHotKey
 $ahkFile = Join-Path $toolsPath 'chocolateyInstall.ahk'
-$ahkProc = Start-Process -FilePath AutoHotkey -ArgumentList "$ahkFile" -PassThru
+$ahkEXE = gci "$env:ChocolateyInstall\lib\autohotkey.portable" -Recurse -filter autohotkey.exe
+$ahkProc = Start-Process -FilePath $ahkEXE.FullName -ArgumentList "$ahkFile" -PassThru
 Write-Debug "AutoHotKey start time:`t$($ahkProc.StartTime.ToShortTimeString())"
 Write-Debug "Process ID:`t$($ahkProc.Id)"
 
 Install-ChocolateyInstallPackage @packageArgs
 
-Get-ChildItem $toolsPath\*.exe | ForEach-Object { Set-Content "$_.ignore" }
+Get-ChildItem $toolsPath\*.exe | ForEach-Object { New-Item "$_.ignore" -Type file -Force | Out-Null}
 
 if (get-process -id $ahkProc.Id -ErrorAction SilentlyContinue) {stop-process -id $ahkProc.Id}

--- a/automatic/pdfcreator/tools/chocolateyInstall.ps1
+++ b/automatic/pdfcreator/tools/chocolateyInstall.ps1
@@ -17,12 +17,11 @@ $installArgs = $('' +
 )
 
 $toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
-$fileLocation = (Get-ChildItem -Path $toolsPath -Filter '*.exe').FullName
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  file           = $fileLocation
+  file           = "$toolsPath\PDFCreator-3_2_2-Setup.exe"
   softwareName   = 'PDFCreator'
   silentArgs     = $installArgs
   validExitCodes = @(0)
@@ -52,6 +51,6 @@ Write-Debug "Process ID:`t$($ahkProc.Id)"
 
 Install-ChocolateyInstallPackage @packageArgs
 
-New-Item "$fileLocation.ignore" -Type file -Force | Out-Null
+Get-ChildItem $toolsPath\*.exe | ForEach-Object { Set-Content "$_.ignore" }
 
 if (get-process -id $ahkProc.Id -ErrorAction SilentlyContinue) {stop-process -id $ahkProc.Id}

--- a/automatic/pdfcreator/tools/chocolateyinstall.ahk
+++ b/automatic/pdfcreator/tools/chocolateyinstall.ahk
@@ -1,0 +1,68 @@
+DetectHiddenWindows, on
+__Welcome:
+; Welcome window
+WinWait, Setup - PDFCreator, Welcome to the PDFCreator Setup Wizard
+WinHide, Setup - PDFCreator, Welcome to the PDFCreator Setup Wizard
+; Next button
+ControlClick, &Next, Setup - PDFCreator, Welcome to the PDFCreator Setup Wizard
+
+__Components:
+; Select Components window
+WinWait, Setup - PDFCreator, Select Components, 1
+if ErrorLevel {
+  if WinExist(Setup - PDFCreator, Welcome to the PDFCreator Setup Wizard) {
+    goto, __Welcome
+  }
+}
+; Next button
+ControlClick, &Next, Setup - PDFCreator, Select Components
+
+__Ready:
+; Ready to Install window
+WinWait, Setup - PDFCreator, Ready to Install, 1
+if ErrorLevel {
+  if WinExist(Setup - PDFCreator, Select Components) {
+    goto, __Components
+  }
+}
+; Install button
+ControlClick, &Install, Setup - PDFCreator, Ready to Install
+
+__PDFArchitect:
+; PDF Architect (Don't want) window
+WinWait, Setup - PDFCreator, PDF Architect, 1
+if ErrorLevel {
+  if WinExist(Setup - PDFCreator, Ready to Install) {
+    goto, __Ready
+  }
+}
+; Next button
+ControlClick, No thanks, Setup - PDFCreator, PDF Architect
+
+__OptionalOffer:
+; Install Complete Optional Offer window (definitely don't want)
+WinWait, Setup - PDFCreator, Installation Completed, 30
+if ErrorLevel {
+  if WinExist(Setup - PDFCreator, PDF Architect) {
+    goto, __OptionalOffer
+  }
+}
+; Skip button
+ControlClick, Skip, Setup - PDFCreator, Installation Completed
+
+__Completing:
+; Completing the PDFCreator Setup Wizard
+WinWait, Setup - PDFCreator, Completing the PDFCreator Setup Wizard, 1
+if ErrorLevel {
+  if WinExist(Setup - PDFCreator, Installation Completed) {
+    goto, __OptionalOffer
+  }
+}
+while WinExist(Setup - PDFCreator, Completing the PDFCreator Setup Wizard) {
+  sleep, 100
+  ; Show Help checkbox
+  ControlClick, TNewCheckListBox1, Setup - PDFCreator, Completing the PDFCreator Setup Wizard
+  sleep, 1000
+  ; Finish button
+  ControlClick, &Finish, Setup - PDFCreator, Completing the PDFCreator Setup Wizard
+}


### PR DESCRIPTION
## Description
* Added an AHK script to walk through the installer without user intervention.  
* Added necessary lines to the chocolateyinstall.ps1 to run the AHK.
* Added an autohotkey.portable dependency in the .NUSPEC (and re-arranged the elements to match the `choco new` template order which I find more logical).

## Motivation and Context
The free, PDFCreator installer is no longer silent and now requires AutoHotKey (or similar) to install without user-intervention.  

## How Has this Been Tested?
Tested install and uninstall on Win7x64 and Win10(Ent1803)x64 and didn't notice any differences in the results from previous pdfcreator installs, *except:*

* The install still opens a URL (to push PDF Architect) on completion, but until there is a Capture-URL function to block installers that do this (something I'm working on), it will have to remain.

I have *not* tested it on the Chocolatey Test Environment because I have never had any luck getting it to work (my own ignorance I guess).  However, the changes I introduced shouldn't break what was obviously working before.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

