### PR TITLE
(nuget.commandline)  Update using tools.json feed

### DIFF
--- a/automatic/nuget.commandline/README.md
+++ b/automatic/nuget.commandline/README.md
@@ -2,3 +2,6 @@
 
 NuGet is the package manager for the Microsoft development platforms including .NET. NuGet gives you access to thousands of packages from other developers on [nuget.org](http://nuget.org), and the NuGet tools let you create, share, and host packages of your own.
 
+## Notes
+
+This package contains **preview** and **released** and **recommended** versions.

--- a/automatic/nuget.commandline/legal/VERIFICATION.txt
+++ b/automatic/nuget.commandline/legal/VERIFICATION.txt
@@ -3,7 +3,7 @@ Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
 The embedded software have been downloaded from the software authors
-nuget package located on <https://www.nuget.org/packages/NuGet.CommandLine/>
+website located at <https://www.nuget.org/downloads>
 and can be verified by doing the following:
 
 1. Download the following <https://api.nuget.org/packages/nuget.commandline.4.7.1.nupkg>

--- a/automatic/nuget.commandline/update.ps1
+++ b/automatic/nuget.commandline/update.ps1
@@ -1,17 +1,9 @@
 import-module au
 
-$packageName = 'NuGet.CommandLine'
+$releases = "https://dist.nuget.org/tools.json"
 
 function global:au_SearchReplace {
    @{
-        # Those might be useful for some other nuget packages
-
-        # ".\tools\chocolateyInstall.ps1" = @{
-        #     "(?i)(^\s*[$]packageName\s*=\s*)('.*')"= "`$1'$packageName'"
-        # }
-        # ".\tools\chocolateyUninstall.ps1" = @{
-        #     "(?i)(^\s*[$]packageName\s*=\s*)('.*')"= "`$1'$packageName'"
-        # }
         ".\legal\VERIFICATION.txt" = @{
           "(?i)(\s*download the.*)<.*>" = "`$1<$($Latest.URL32)>"
           "(?i)(^\s*checksum\s*type\:).*" = "`${1} $($Latest.ChecksumType32)"
@@ -22,19 +14,16 @@ function global:au_SearchReplace {
 
 function global:au_BeforeUpdate {
     Get-RemoteFiles -Purge -NoSuffix
-
-    set-alias 7z $Env:chocolateyInstall\tools\7z.exe
-    rm tools\*.exe
-    7z e tools\*.nupkg NuGet.exe -r -otools
-    rm tools\*.nupkg
 }
 
 function global:au_GetLatest {
-    $package = Find-Package $packageName -provider "nuget" -Source http://www.nuget.org/api/v2/ -AllowPrereleaseVersions -Force
-    $version = $package.Version
+    $json = Invoke-WebRequest -UseBasicParsing -Uri $releases | ConvertFrom-Json
+
+    $latestVersion = $json."nuget.exe" | Sort-Object uploaded -Descending | Select-Object -First 1
+
     @{
-        Version = $version
-        Url32   = "https://api.nuget.org/packages/$($packageName.ToLower()).${version}.nupkg"
+        Version = $latestVersion.version
+        Url32   = $latestVersion.url
     }
 }
 


### PR DESCRIPTION
## Description
Update nuget.commandline package using tools.json feed instead from nuget.commandline NuGet package.

## Motivation and Context
In the past few versions several time the nuget.commandline package was not updated after the NuGet package reached recommodation/blessing state. This PR changes update to use the JSON file describing all versions. It also updates as soon as a new released version is available even if it is not the recommended/blessed version yet (like currently 4.8.1)

Fixes #1076

## How Has this Been Tested?
Tested update locally

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
