### PR TITLE
(vagrant) `vagrant plugin repair` failure is no longer fatal

### DIFF
--- a/automatic/vagrant/tools/chocolateyinstall.ps1
+++ b/automatic/vagrant/tools/chocolateyinstall.ps1
@@ -16,4 +16,10 @@ $packageArgs = @{
 Install-ChocolateyPackage @packageArgs
 
 Update-SessionEnvironment
-vagrant plugin repair  #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1024
+
+$ErrorActionPreference = 'Continue' #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1099
+vagrant plugin repair               #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1024
+if ($LastExitCode -ne 0) {          #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1099
+  Write-Host "WARNING: Plugin repair failed, run 'vagrant plugin expunge --reinstall' after rebooting."
+}
+$LastExitCode = 0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->
Warn on plugin repair failure instead of failing the whole install since vagrant is technically installed correctly.

## Description
<!-- Describe your changes in detail -->
Instead of letting a failed exit code from `vagrant plugin repair` bubble out of `chocolateyinstall.ps1`, trap the error and issue a warning.
It is a known issue that sometimes vagrant plugin repair will fail after an upgrade, so we shouldn't fail the vagrant installation. See https://www.vagrantup.com/docs/cli/plugin.html for more information.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
Fixes https://github.com/chocolatey/chocolatey-coreteampackages/issues/1099

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
Used "AU" package and ran `Test-Package` to verify that the vagrant installation succeeds even if plugin repair fails.  Also tested a when vagrant plugin repair does not error.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
