### PR TITLE
(Skype) Changed InnoSetup /SILENT parameter to /VERYSILENT

### DIFF
--- a/automatic/skype/tools/chocolateyInstall.ps1
+++ b/automatic/skype/tools/chocolateyInstall.ps1
@@ -6,7 +6,7 @@ $packageArgs = @{
   url            = 'https://endpoint920510.azureedge.net/s4l/s4l/download/win/Skype-8.30.0.50.exe'
   checksum       = '5b769d80f0916e7e82a422481062b9e558449cf3542983883e4622d5e49618f8'
   checksumType   = 'sha256'
-  silentArgs     = "/SILENT /SUPPRESSMSGBOXES /NORESTART /SP- /LOG=`"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).InnoInstall.log`""
+  silentArgs     = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /LOG=`"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).InnoInstall.log`""
   validExitCodes = @(0)
 }
 


### PR DESCRIPTION
## Description
Using /VERYSILENT instead of /SILENT makes Inno Setup a bit quieter.

## Motivation and Context
Users are understandably concerned about "mystery" install windows.

## How Has this Been Tested?
Manually downloaded https://endpoint920510.azureedge.net/s4l/s4l/download/win/Skype-8.30.0.50.exe, and ran installer with same parameters as in chocolateyInstall.ps1, except /SILENT was changed to /VERYSILENT. Installation succeeded and no installation windows appeared. Skype still (re)launches after installation.

## Types of changes
Minor (largely cosmetic) change

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).