### PR TITLE
KB* packages - Work around Boxstarter issue

### DIFF
--- a/manual/kb2670838/Tools/ChocolateyInstall.ps1
+++ b/manual/kb2670838/Tools/ChocolateyInstall.ps1
@@ -16,4 +16,4 @@ $servicePackRequirements = @{
   '6.1' = @{ ServicePackNumber = 1; ChocolateyPackage = 'KB976932' }
 }
 
-Install-WindowsUpdate -Id 'KB2670838' -MsuData $msuData -ChecksumType 'sha256' -ServicePackRequirements $servicePackRequirements
+chocolateyInstaller\Install-WindowsUpdate -Id 'KB2670838' -MsuData $msuData -ChecksumType 'sha256' -ServicePackRequirements $servicePackRequirements

--- a/manual/kb2670838/kb2670838.nuspec
+++ b/manual/kb2670838/kb2670838.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>KB2670838</id>
-        <version>1.0.20170428</version>
+        <version>1.0.20181019</version>
         <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/manual/kb2670838</packageSourceUrl>
         <owners>chocolatey</owners>
         <title>Platform update for Windows 7 SP1 and Windows Server 2008 R2 SP1</title>

--- a/manual/kb2999226/kb2999226.nuspec
+++ b/manual/kb2999226/kb2999226.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>KB2999226</id>
-    <version>1.0.20170509</version>
+    <version>1.0.20181019</version>
     <title>Update for Universal C Runtime in Windows (KB2999226)</title>
     <authors>Microsoft</authors>
     <owners>chocolatey,RB</owners>
@@ -16,6 +16,7 @@
     This update applies to the following operating systems: Windows Server 2012 R2 Datacenter, Windows Server 2012 R2 Standard, Windows Server 2012 R2 Essentials, Windows Server 2012 R2 Foundation, Windows 8.1 Enterprise, Windows 8.1 Pro, Windows 8.1, Windows RT 8.1, Windows Server 2012 Datacenter, Windows Server 2012 Standard, Windows Server 2012 Essentials, Windows Server 2012 Foundation, Windows 8 Enterprise, Windows 8 Pro, Windows 8, Windows RT, Windows Server 2008 R2 Service Pack 1, Windows 7 Service Pack 1, Windows Server 2008 Service Pack 2, Windows Vista Service Pack 2</description>
     <summary>Update for Universal C Runtime (CRT) in Windows. Before you install this update, check out the prerequisites section.</summary>
     <releaseNotes>
+* 1.0.20181019: Ensure the correct Install-WindowsUpdate function is called (work around [Boxstarter issue](https://github.com/chocolatey/boxstarter/issues/293))
 * 1.0.20170509: Fixed KB id in install script
 * 1.0.20170422: Changed to use chocolatey-windowsupdate.extension
 * 1.0.20161201: Fixed installation for windows 10 versions

--- a/manual/kb2999226/tools/chocolateyinstall.ps1
+++ b/manual/kb2999226/tools/chocolateyinstall.ps1
@@ -48,4 +48,4 @@ $servicePackRequirements = @{
   '6.1' = @{ ServicePackNumber = 1; ChocolateyPackage = 'KB976932' }
 }
 
-Install-WindowsUpdate -Id 'KB2999226' -MsuData $msuData -ChecksumType 'sha256' -ServicePackRequirements $servicePackRequirements
+chocolateyInstaller\Install-WindowsUpdate -Id 'KB2999226' -MsuData $msuData -ChecksumType 'sha256' -ServicePackRequirements $servicePackRequirements


### PR DESCRIPTION
## Description
Use module-qualified cmdlet name for Install-WindowsUpdate, to prevent accidental clash with the Install-WindowsUpdate command from BoxStarter. 

## Motivation and Context
When using Boxstarter to install chocolatey packages, the Install-WindowsUpdate command with the same name from Boxstarter gets called. This installs ALL critical Windows updates by default, which is unwanted behavior. To work around this issue, please ensure the correct Install-WindowsUpdate is called. See [here the relevant boxstarter issue](https://github.com/chocolatey/boxstarter/issues/293). The same fix was implemented by jberezanski on the KB-packages he maintains, see [the discussion around this fix here](https://github.com/jberezanski/ChocolateyPackages/pull/54) and [the commit with his fix here](https://github.com/jberezanski/ChocolateyPackages/commit/8472735fc039836e6299157f700f13a6572a3acb).

## How Has this Been Tested?
This fix has been tested using Boxstarter on Windows Server 2016 Standard. 

Before fix: Install-WindowsUpdate from BoxStarter.WinConfig is called, resulting in all critical Windows updates being installed.

After fix: Install-WindowsUpdate from chocolateyInstaller is called as expected.

See the relevant logging [here](https://github.com/jberezanski/ChocolateyPackages/pull/54).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package). **Does not require an update to the descriptions. I have however updated the release notes section for KB2999226 accordingly.**
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package). **Does not require an update to the descriptions. I have however updated the release notes section for KB2999226 accordingly.**
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment. **Can't get this working on my machine, maybe someone else can test this if it is deemed necessary for such a minor change?**
- [ ] The changes only affect a single package (not including meta package). **As per section 3.4 in the contribution guidelines, this falls under the exception 'specific special cases that fix common problem'.**