### PR TITLE
Add/Remove a sym-link for docker tray Kitematic menu item

### DIFF
--- a/automatic/docker-kitematic/tools/chocolateyInstall.ps1
+++ b/automatic/docker-kitematic/tools/chocolateyInstall.ps1
@@ -3,6 +3,7 @@
 $packageName = 'docker-kitematic'
 
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+$kitematicExe = Join-Path $toolsPath "Kitematic.exe"
 
 $packageArgs = @{
   PackageName    = $packageName
@@ -21,5 +22,13 @@ foreach ($file in $files) {
 $desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::DesktopDirectory))
 $link = Join-Path $desktop "Kitematic.lnk"
 if (!(Test-Path $link)) {
-    Install-ChocolateyShortcut -ShortcutFilePath "$link" -TargetPath "$toolsPath\Kitematic.exe" -WorkingDirectory "$toolsPath"
+    Install-ChocolateyShortcut -ShortcutFilePath "$link" -TargetPath $kitematicExe -WorkingDirectory "$toolsPath"
+}
+
+# Create sym-link for docker tray menu
+$kitematicDir = Join-Path $env:ProgramFiles "Docker\Kitematic"
+$kitematicLink = Join-Path $kitematicDir "kitematic.exe"
+New-Item -Path $kitematicDir -ItemType Directory -Force | Out-Null
+if (!(Test-Path $kitematicLink)) {
+	& cmd /c mklink $kitematicLink $kitematicExe
 }

--- a/automatic/docker-kitematic/tools/chocolateyUninstall.ps1
+++ b/automatic/docker-kitematic/tools/chocolateyUninstall.ps1
@@ -5,3 +5,10 @@ $link = Join-Path $desktop "Kitematic.lnk"
 If (Test-Path $link) {
     Remove-Item "$link"
 }
+
+# Remove docker tray sym-link
+$kitematicDir = Join-Path $env:ProgramFiles "Docker\Kitematic"
+$kitematicLink = Join-Path $kitematicDir "kitematic.exe"
+if (Test-Path $kitematicLink) {
+	Remove-Item $kitematicLink
+}


### PR DESCRIPTION
Add a symbolic link to allow the docker tray Kitematic menu option to work after installing Kitematic via the choco package.

## Description
The docker tray icon has a menu item 'Kitematic'. Clicking on this when Kitematic is not installed displays a message to install it to C:\Program Files\Docker\Kitematic. This package installs Kitematic into the chocolatey directory under C:\ProgramData\... 

This change adds a symbolic link which points from C:\Program Files\Docker\Kitematic\kitematic.exe to C:\ProgramData\Chocolatey\lib\docker-kitematic\tools\kitematic.exe

This allows the docker tray icon menu item to work when installing Kitematic from a choco package.

## Motivation and Context
After installing Kitematic the user doesn't need to manually move or install into the %ProgramFiles%\Docker\Kitematic directory.

## How Has this Been Tested?

### create new package
> choco pack

### basic install. not already installed, no Docker\Kitematic dir or sym-link
> choco install docker-kitematic -dv -s .

### install again.
> choco install docker-kitematic -dv -s . -Force

### uninstall
> choco uninstall docker-kitematic

No warnings or errors.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).