### PR TITLE
(cygwin): fix copied setup file

### DIFF
--- a/automatic/cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/cygwin/tools/chocolateyInstall.ps1
@@ -49,5 +49,5 @@ Install-ChocolateyInstallPackage @packageArgs
 Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
-$setup_path = if (Get-OSArchitectureWidth 32 -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
+$setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
 Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force


### PR DESCRIPTION
Forcing Cygwin to install x86 version in a 64-bit system works, but later installing packages for Cygwin doesn't because the copied setup executable is wrong.

## Description
Adding parenthesis for calling the Get-OSArchitectureWidth function

## Motivation and Context
I'm not an experienced PowerShell user or developer, but my guess is that the `-or` takes precedence. So we need to make the function call take precedence.

## How Has this Been Tested?
Only tested in my environment. Sorry for not complying here, but I lack time for it.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).