### PR TITLE
RFP - Google Chrome Beta #494

### DIFF
--- a/automatic/googlechromebeta/README.md
+++ b/automatic/googlechromebeta/README.md
@@ -1,4 +1,4 @@
-# <img src="https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/chrome.svg" width="48" height="48"/> [GoogleChrome](https://chocolatey.org/packages/GoogleChrome)
+# <img src="https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/chrome.svg" width="48" height="48"/> [Google Chrome Beta](https://chocolatey.org/packages/googlechromebeta)
 
 
 Chrome is a fast, simple, and secure web browser, built for the modern web.

--- a/automatic/googlechromebeta/README.md
+++ b/automatic/googlechromebeta/README.md
@@ -1,0 +1,10 @@
+# <img src="https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/chrome.svg" width="48" height="48"/> [GoogleChrome](https://chocolatey.org/packages/GoogleChrome)
+
+
+Chrome is a fast, simple, and secure web browser, built for the modern web.
+
+### Notes
+
+* This package uses Chrome's administrative MSI installer and installs the 32-bit on 32-bit OSes and the 64-bit version on 64-bit OSes. If this package is installed on a 64-bit OS and the 32-bit version of Chrome is already installed, the package keeps installing/updating the 32-bit version of Chrome.
+* This package always installs the latest version of Google Chrome Beta, regardless of the version specified in the package. Google does not officially offer older versions of Chrome for download. Because of this you may get checksum mismatch between the time Google releases a new installer, and the package is automatically updated.
+

--- a/automatic/googlechromebeta/googlechromebeta.nuspec
+++ b/automatic/googlechromebeta/googlechromebeta.nuspec
@@ -22,7 +22,7 @@ Chrome is a fast, simple, and secure web browser, built for the modern web.
 
 ]]></description>
     <releaseNotes></releaseNotes>
-    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/googlechrome</packageSourceUrl>
+    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/googlechromebeta</packageSourceUrl>
     <tags>google chrome beta web internet browser admin</tags>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />

--- a/automatic/googlechromebeta/googlechromebeta.nuspec
+++ b/automatic/googlechromebeta/googlechromebeta.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>GoogleChromeBeta</id>
+    <version>72.0.3626.17</version>
+    <title>Google Chrome Beta</title>
+    <owners>chocolatey</owners>
+    <authors>Google Inc.</authors>
+    <projectUrl>https://www.google.com/chrome/browser/</projectUrl>
+    <licenseUrl>https://www.google.it/intl/en/chrome/browser/privacy/eula_text.html</licenseUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/chrome.svg</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description><![CDATA[
+Chrome is a fast, simple, and secure web browser, built for the modern web.
+
+### Notes
+
+* This package uses Chrome's administrative MSI installer and installs the 32-bit on 32-bit OSes and the 64-bit version on 64-bit OSes. If this package is installed on a 64-bit OS and the 32-bit version of Chrome is already installed, the package keeps installing/updating the 32-bit version of Chrome.
+* This package always installs the latest version of Google Chrome Beta, regardless of the version specified in the package. Google does not officially offer older versions of Chrome for download. Because of this you may get checksum mismatch between the time Google releases a new installer, and the package is automatically updated.
+* This package installs side-by-side with Google Chrome.
+
+]]></description>
+    <releaseNotes></releaseNotes>
+    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/googlechrome</packageSourceUrl>
+    <tags>google chrome beta web internet browser admin</tags>
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.3.3" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/automatic/googlechromebeta/googlechromebeta.nuspec
+++ b/automatic/googlechromebeta/googlechromebeta.nuspec
@@ -2,7 +2,7 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>GoogleChromeBeta</id>
+    <id>GoogleChrome.Beta</id>
     <version>72.0.3626.17</version>
     <title>Google Chrome Beta</title>
     <owners>chocolatey</owners>

--- a/automatic/googlechromebeta/googlechromebeta.nuspec
+++ b/automatic/googlechromebeta/googlechromebeta.nuspec
@@ -5,7 +5,7 @@
     <id>GoogleChrome.Beta</id>
     <version>72.0.3626.17</version>
     <title>Google Chrome Beta</title>
-    <owners>chocolatey</owners>
+    <owners>chocolatey,nsleigh</owners>
     <authors>Google Inc.</authors>
     <projectUrl>https://www.google.com/chrome/browser/</projectUrl>
     <licenseUrl>https://www.google.it/intl/en/chrome/browser/privacy/eula_text.html</licenseUrl>

--- a/automatic/googlechromebeta/googlechromebeta.nuspec
+++ b/automatic/googlechromebeta/googlechromebeta.nuspec
@@ -2,8 +2,8 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>GoogleChrome.Beta</id>
-    <version>72.0.3626.17</version>
+    <id>googlechromebeta</id>
+    <version>72.0.3626.53</version>
     <title>Google Chrome Beta</title>
     <owners>chocolatey,nsleigh</owners>
     <authors>Google Inc.</authors>
@@ -18,15 +18,10 @@ Chrome is a fast, simple, and secure web browser, built for the modern web.
 
 * This package uses Chrome's administrative MSI installer and installs the 32-bit on 32-bit OSes and the 64-bit version on 64-bit OSes. If this package is installed on a 64-bit OS and the 32-bit version of Chrome is already installed, the package keeps installing/updating the 32-bit version of Chrome.
 * This package always installs the latest version of Google Chrome Beta, regardless of the version specified in the package. Google does not officially offer older versions of Chrome for download. Because of this you may get checksum mismatch between the time Google releases a new installer, and the package is automatically updated.
-* This package installs side-by-side with Google Chrome.
 
 ]]></description>
-    <releaseNotes></releaseNotes>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/googlechromebeta</packageSourceUrl>
     <tags>google chrome beta web internet browser admin</tags>
-    <dependencies>
-      <dependency id="chocolatey-core.extension" version="1.3.3" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/googlechromebeta/tools/chocolateyInstall.ps1
+++ b/automatic/googlechromebeta/tools/chocolateyInstall.ps1
@@ -1,0 +1,24 @@
+﻿$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+. $toolsPath\helpers.ps1
+
+$version = '72.0.3626.17'
+if ($version -eq (Get-ChromeBetaVersion)) {
+  Write-Host "Google Chrome Beta $version is already installed."
+  return
+}
+
+$packageArgs = @{
+  packageName            = 'googlechrome'
+  fileType               = 'MSI'
+  url                    = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise.msi'
+  url64bit               = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise64.msi'
+  checksum               = '88360f09f72cf7d1c68445b4401336a2572ca6b88cade6da75904dce9ec483a6'
+  checksum64             = 'f9d4eb20f4c65f07e77fffb6b0363e6b1b4a66317cbc36ca66b3c770a7a6b0b4'
+  checksumType           = 'sha256'
+  checksumType64         = 'sha256'
+  silentArgs             = "/quiet /norestart /l*v `"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+  validExitCodes         = @(0)
+}
+
+if (Get-Chrome32bitInstalled) { 'url64bit', 'checksum64', 'checksumType64' | ForEach-Object { $packageArgs.Remove($_) } }
+Install-ChocolateyPackage @packageArgs

--- a/automatic/googlechromebeta/tools/chocolateyInstall.ps1
+++ b/automatic/googlechromebeta/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 . $toolsPath\helpers.ps1
 
-$version = '72.0.3626.17'
+$version = '72.0.3626.53'
 if ($version -eq (Get-ChromeBetaVersion)) {
   Write-Host "Google Chrome Beta $version is already installed."
   return
@@ -12,8 +12,8 @@ $packageArgs = @{
   fileType               = 'MSI'
   url                    = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise.msi'
   url64bit               = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise64.msi'
-  checksum               = '88360f09f72cf7d1c68445b4401336a2572ca6b88cade6da75904dce9ec483a6'
-  checksum64             = 'f9d4eb20f4c65f07e77fffb6b0363e6b1b4a66317cbc36ca66b3c770a7a6b0b4'
+  checksum               = '7c37e0458cc8e37a456890e07916de4dbdabdaa22e1e9499c21b1550efa89893'
+  checksum64             = 'fcac4ebeb83c5eaf41ae390d2a2d9008512f04bb836b2b3ac9a63f953960b5b0'
   checksumType           = 'sha256'
   checksumType64         = 'sha256'
   silentArgs             = "/quiet /norestart /l*v `"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).MsiInstall.log`""

--- a/automatic/googlechromebeta/tools/helpers.ps1
+++ b/automatic/googlechromebeta/tools/helpers.ps1
@@ -1,0 +1,29 @@
+﻿function Get-Chrome32bitInstalled {
+  $registryPath = 'HKLM:\SOFTWARE\WOW6432Node\Google\Update\ClientState\*'
+  # We also return nothing if the user forces 32bit installation
+  # as we don't need to make any checks in that case.
+  if (!(Test-Path $registryPath) -or $env:ChocolateyForceX86 -eq $true) { return }
+
+  $32bitInstalled = Get-Item $registryPath | ForEach-Object {
+    if ((Get-ItemProperty $_.pspath).ap -match 'arch_x86$') { return $true }
+  }
+  if ($32bitInstalled) {
+    return $32bitInstalled
+  }
+
+  $installLocation = Get-UninstallRegistryKey 'Google Chrome Beta' | ForEach-Object { $_.InstallSource }
+  if ($installLocation) {
+    return Test-Path "$installLocation\nacl_irt_x86_32.nexe"
+  } else {
+    Write-Warning "Unable to find the architecture of the installed Google Chrome Beta application"
+  }
+}
+
+function Get-ChromeBetaVersion() {
+  $root   = 'HKLM:\SOFTWARE\Google\Update\Clients'
+  $root64 = 'HKLM:\SOFTWARE\Wow6432Node\Google\Update\Clients'
+  foreach ($r in $root,$root64) {
+    $gcb = Get-ChildItem $r -ea 0 | Where-Object { (Get-ItemProperty $_.PSPath).name -eq 'Google Chrome Beta' }
+    if ($gcb) { return $gcb.GetValue('pv') }
+  }
+}

--- a/automatic/googlechromebeta/update.ps1
+++ b/automatic/googlechromebeta/update.ps1
@@ -1,0 +1,37 @@
+﻿import-module au
+import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
+
+$releases = 'http://omahaproxy.appspot.com/all?os=win&amp;channel=beta'
+$paddedUnderVersion = '57.0.2988'
+
+function global:au_BeforeUpdate {
+  $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32
+  $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64
+}
+
+function global:au_SearchReplace {
+  @{
+    ".\tools\chocolateyInstall.ps1" = @{
+      "(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
+      "(?i)(^\s*url64bit\s*=\s*)('.*')" = "`$1'$($Latest.URL64)'"
+      "(?i)(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+      "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+      "(?i)(^[$]version\s*=\s*)('.*')" = "`$1'$($Latest.RemoteVersion)'"
+    }
+  }
+}
+
+function global:au_GetLatest {
+  $release_info = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $version = $release_info | % Content | ConvertFrom-Csv | % current_version
+
+  @{
+    URL32 = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise.msi'
+    URL64 = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise64.msi'
+    Version = Get-FixVersion $version -OnlyFixBelowVersion $paddedUnderVersion
+    RemoteVersion = $version
+    PackageName = 'GoogleChromeBeta'
+  }
+}
+
+update -ChecksumFor none

--- a/automatic/googlechromebeta/update.ps1
+++ b/automatic/googlechromebeta/update.ps1
@@ -30,7 +30,6 @@ function global:au_GetLatest {
     URL64 = 'https://dl.google.com/tag/s/dl/chrome/install/beta/googlechromebetastandaloneenterprise64.msi'
     Version = Get-FixVersion $version -OnlyFixBelowVersion $paddedUnderVersion
     RemoteVersion = $version
-    PackageName = 'GoogleChromeBeta'
   }
 }
 

--- a/automatic/googlechromebeta/update.ps1
+++ b/automatic/googlechromebeta/update.ps1
@@ -1,7 +1,7 @@
 ﻿import-module au
 import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'http://omahaproxy.appspot.com/all?os=win&amp;channel=beta'
+$releases = 'https://omahaproxy.appspot.com/all?os=win&channel=beta'
 $paddedUnderVersion = '57.0.2988'
 
 function global:au_BeforeUpdate {


### PR DESCRIPTION
New package based on the existing GoogleChrome package that will install the Google Chrome Beta version side-by-side with the standard Google Chrome package.

## Description
Add new googlechromebeta package.

## Motivation and Context
The beta version is useful for tests UIs to ensure they are compatible with the next release of Chrome.

## How Has this Been Tested?
Package has been built and tested locally, both installing and uninstalling.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
