### PR TITLE
Do not embed Mixxx anymore as we have overtaken Cloudflare size limit

### DIFF
--- a/automatic/mixxx/tools/chocolateyInstall.ps1
+++ b/automatic/mixxx/tools/chocolateyInstall.ps1
@@ -3,18 +3,19 @@
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
-  packageName    = 'mixxx'
+  packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  file           = Get-Item $toolsPath\*-win32.exe
-  file64         = Get-Item $toolsPath\*-win64.exe
+  url            = ''
+  url64bit       = ''
+
+  softwareName   = 'Mixxx *'
+
+  checksum       = ''
+  checksumType   = ''
+  checksum64     = ''
+  checksumType64 = ''
+
   silentArgs     = '/quiet'
   validExitCodes = @(0)
-  softwareName   = 'Mixxx *'
 }
-Install-ChocolateyInstallPackage @packageArgs
-Get-ChildItem $toolsPath\*.exe | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" '' }}
-
-
-$installLocation = Get-AppInstallLocation $packageArgs.softwareName
-if (!$installLocation)  { Write-Warning "Can't find install location"; return }
-Write-Host "Installed to '$installLocation'"
+Install-ChocolateyPackage @packageArgs

--- a/automatic/mixxx/update.ps1
+++ b/automatic/mixxx/update.ps1
@@ -10,10 +10,16 @@ function global:au_SearchReplace {
             "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
             "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
         }
+        "tools\chocolateyInstall.ps1" = @{
+            "(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
+            "(?i)(^\s*url64bit\s*=\s*)('.*')" = "`$1'$($Latest.URL64)'"
+            "(?i)(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+            "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+            "(?i)(^\s*checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
+            "(?i)(^\s*checksumType64\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType64)'"
+        }
     }
 }
-
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
@@ -25,7 +31,9 @@ function global:au_GetLatest {
         Version = $version.Replace('mixxx-', '')
         URL32   = $url | ? { $_ -like '*win32*' } | select -First 1
         URL64   = $url | ? { $_ -like '*win64*' } | select -First 1
+        ChecksumType32 = 'sha512'
+        ChecksumType64 = 'sha512'
     }
 }
 
-update -ChecksumFor none
+update


### PR DESCRIPTION
## Description
Do not embed Mixxx anymore as we have overtaken Cloudflare size limit

## Motivation and Context
Fix #1179 

## How Has this Been Tested?
Local test on Windows 10 Pro: update, cpakc install and uninstall went smoothly

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- x ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).