### PR TITLE
(mp3tag) Embedded package, fix for #1090

### DIFF
--- a/automatic/mp3tag/README.md
+++ b/automatic/mp3tag/README.md
@@ -3,3 +3,9 @@
 
 Mp3tag is a powerful and yet easy-to-use tool to edit metadata of common audio formats where it supports ID3v1, ID3v2.3, ID3v2.4, iTunes MP4, WMA, Vorbis Comments and APE Tags.
 
+## Parameters
+- `/NoDesktopShortcut` - Do not create desktop shortcut for Mp3tag
+- `/NoContextMenu` - Do not add Mp3tag to context menu
+
+These parameters can be passed to the installer with the use of `--params`.
+For example: `--params '"/NoDesktopShortcut /NoContextMenu"'`

--- a/automatic/mp3tag/README.md
+++ b/automatic/mp3tag/README.md
@@ -7,5 +7,5 @@ Mp3tag is a powerful and yet easy-to-use tool to edit metadata of common audio f
 - `/NoDesktopShortcut` - Do not create desktop shortcut for Mp3tag
 - `/NoContextMenu` - Do not add Mp3tag to context menu
 
-These parameters can be passed to the installer with the use of `--params`.
-For example: `--params '"/NoDesktopShortcut /NoContextMenu"'`
+These parameters can be passed to the installer with the use of `--package-parameters`.
+For example: `choco install --package-parameters='"/NoDesktopShortcut /NoContextMenu"'`

--- a/automatic/mp3tag/legal/LICENSE.txt
+++ b/automatic/mp3tag/legal/LICENSE.txt
@@ -1,4 +1,4 @@
-Mp3tag v2.91 Copyright ©1999-2018 Florian Heidenreich
+Mp3tag v2.91 Copyright Â©1999-2018 Florian Heidenreich
 
 Mp3tag v2.91 is designed for private use and commercial use without sale ("Freeware"), if the following rules are respected:
 

--- a/automatic/mp3tag/legal/LICENSE.txt
+++ b/automatic/mp3tag/legal/LICENSE.txt
@@ -1,0 +1,13 @@
+Mp3tag v2.91 Copyright ©1999-2018 Florian Heidenreich
+
+Mp3tag v2.91 is designed for private use and commercial use without sale ("Freeware"), if the following rules are respected:
+
+The author, Florian Heidenreich has no responsibility if errors occurs in direct or indirect relation with the software.
+
+Mp3tag v2.91 cannot be used in a military domain or in a similar domain (Weapon creation, armament, etc.).
+
+Mp3tag v2.91 can be distributed through non-commercial channels, if the delivery happens in the form of the self-extracting setup file available from http://www.mp3tag.de.
+
+Mp3tag v2.91 can be distributed through commercial channels if the author, Florian Heidenreich, agrees this delivery and if the delivery happens in the form of the self-extracting setup file available from http://www.mp3tag.de.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/automatic/mp3tag/legal/VERIFICATION.txt
+++ b/automatic/mp3tag/legal/VERIFICATION.txt
@@ -1,0 +1,19 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+The embedded software have been downloaded from the listed download
+location on <>
+and can be verified by doing the following:
+
+1. Download the following:
+  32-Bit software: <>
+2. Get the checksum using one of the following methods:
+  - Using powershell function 'Get-FileHash'
+  - Use chocolatey utility 'checksum.exe'
+3. The checksums should match the following:
+
+  checksum type:
+  checksum32:
+
+The file 'LICENSE.txt' has been obtained from <http://help.mp3tag.de/misc_license.html>

--- a/automatic/mp3tag/tools/ChocolateyInstall.ps1
+++ b/automatic/mp3tag/tools/ChocolateyInstall.ps1
@@ -1,17 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$packageName = 'mp3tag'
-$url32       = 'http://download.mp3tag.de/mp3tagv291setup.exe'
-$checksum32  = 'd887ae908ba31ee2f47b15d228cf594656aa217242ca38bf91b55c1133f1e346'
-$silentArgs  = '/S'
-
-$PSScriptRoot = Split-Path -parent $MyInvocation.MyCommand.Definition
-
-# The installer doesn’t like being renamed. The installation wouldn’t be
-# silent if it is renamed. Therefore the original filename is parsed
-# from the URL
-$installerPath = Join-Path $PSScriptRoot $url32.Split('/')[-1]
-$iniFile = Join-Path $PSScriptRoot 'Mp3tagSetup.ini'
+$toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
+$iniFile = Join-Path $toolsPath 'Mp3tagSetup.ini'
 
 # Automatic language selection
 $LCID = (Get-Culture).LCID
@@ -29,18 +19,13 @@ language=$LCID
 New-Item $iniFile -type file -force -value $iniContent
 
 $packageArgs = @{
-  packageName            = $packageName
-  fileFullPath           = $installerPath
-  fileType               = 'EXE'
-  url                    = $url32
-  checksum               = $checksum32
-  checksumType           = 'sha256'
+  packageName    = $env:ChocolateyPackageName
+  fileType       = 'exe'
+  file           = "$toolsPath\"
+  silentArgs     = "/S"
+  validExitCodes = @(0)
 }
 
-Get-ChocolateyWebFile @packageArgs
+Install-ChocolateyInstallPackage @packageArgs
 
-# Download the file to $PSScriptRoot.
-# Using Chocolatey’s Installer-ChocolateyPackage function isn’t a good idea here
-# because the path where the installer is downloaded could change and
-# the ini file needs to be in the same folder to work.
-Install-ChocolateyInstallPackage $packageName $fileType $silentArgs $installerPath
+Get-ChildItem $toolsPath\*.exe | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" } }

--- a/automatic/mp3tag/tools/ChocolateyInstall.ps1
+++ b/automatic/mp3tag/tools/ChocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 
 $pp = Get-PackageParameters
 $toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition

--- a/automatic/mp3tag/tools/ChocolateyInstall.ps1
+++ b/automatic/mp3tag/tools/ChocolateyInstall.ps1
@@ -1,15 +1,18 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+$pp = Get-PackageParameters
 $toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
 $iniFile = Join-Path $toolsPath 'Mp3tagSetup.ini'
 
+$desktop = if ($pp.NoDesktopShortcut) { 0 } else { 1 }
+$explorer = if ($pp.NoContextMenu) { 0 } else { 1 }
 # Automatic language selection
 $LCID = (Get-Culture).LCID
 $iniContent = @"
 [shortcuts]
 startmenu=1
-desktop=1
-explorer=1
+desktop=$desktop
+explorer=$explorer
 
 [language]
 language=$LCID

--- a/automatic/mp3tag/update.ps1
+++ b/automatic/mp3tag/update.ps1
@@ -2,15 +2,18 @@ import-module au
 
 $releases = 'http://www.mp3tag.de/en/download.html'
 
-function global:au_BeforeUpdate {
-  $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32
-}
+function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_SearchReplace {
    @{
+        ".\legal\VERIFICATION.txt"      = @{
+          "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$releases>"
+          "(?i)(\s*32\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL32)>"
+          "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType32)"
+          "(?i)(^\s*checksum(32)?\:).*"       = "`${1} $($Latest.Checksum32)"
+        }
         ".\tools\ChocolateyInstall.ps1" = @{
-            "(^[$]url32\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
-            "(^[$]checksum32\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+            "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*"   = "`${1}$($Latest.FileName32)`""
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
This makes the package embedded, so it resolves #866 for mp3tag. I added legal folder with verification file and license and of course, made the update script embed installers.
I can't try it on more old versions (cause apparently only the newest version's link is still active), but this fixes #1090. 
Also I added 2 optional install parameters:
`/NoDesktopShortcut` - Do not create desktop shortcut for Mp3tag
`/NoContextMenu` - Do not add Mp3tag to context menu

## Motivation and Context
Package should be embedded if allowed and this app's license allows us to embed the installer. (#866)
Old installers are left behind on package upgrade and this fixes it (#1090)
Some people don't want their desktop to be cluttered by shortcuts and some may not want to clutter context menu, so I added those 2 parameters.

## How Has this Been Tested?
I checked update.ps1, to see if it works properly, I tested the package in testing environment to see, if it's installed and uninstalled properly. Unfortunately silent uninstall is not currently possible, but may be added in future - [link](https://community.mp3tag.de/t/can-i-do-silent-unattended-uninstall-of-mp3tag/44196/2)
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
