### PR TITLE
graphviz: Add more layout engines to bin files

### DIFF
--- a/automatic/graphviz/tools/chocolateyInstall.ps1
+++ b/automatic/graphviz/tools/chocolateyInstall.ps1
@@ -19,3 +19,6 @@ if (!$installLocation)  { Write-Warning "Can't find $packageName install locatio
 Write-Host "$packageName installed to '$installLocation'"
 
 Install-BinFile dot $installLocation\bin\dot.exe
+Install-BinFile circo $installLocation\bin\circo.exe
+Install-BinFile sfdp $installLocation\bin\sfdp.exe
+Install-BinFile twopi $installLocation\bin\twopi.exe

--- a/automatic/graphviz/tools/chocolateyInstall.ps1
+++ b/automatic/graphviz/tools/chocolateyInstall.ps1
@@ -18,7 +18,4 @@ $installLocation = Get-AppInstallLocation $packageArgs.softwareName
 if (!$installLocation)  { Write-Warning "Can't find $packageName install location"; return }
 Write-Host "$packageName installed to '$installLocation'"
 
-Install-BinFile dot $installLocation\bin\dot.exe
-Install-BinFile circo $installLocation\bin\circo.exe
-Install-BinFile sfdp $installLocation\bin\sfdp.exe
-Install-BinFile twopi $installLocation\bin\twopi.exe
+@('dot','circo','sfdp','twopi') |% {Install-BinFile $_ "$installLocation\bin\$_.exe"}

--- a/automatic/graphviz/tools/chocolateyUninstall.ps1
+++ b/automatic/graphviz/tools/chocolateyUninstall.ps1
@@ -1,6 +1,3 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-Uninstall-BinFile dot
-Uninstall-BinFile circo
-Uninstall-BinFile sfdp
-Uninstall-BinFile twopi
+@('dot','circo','sfdp','twopi') |% {Uninstall-BinFile $_}

--- a/automatic/graphviz/tools/chocolateyUninstall.ps1
+++ b/automatic/graphviz/tools/chocolateyUninstall.ps1
@@ -1,3 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 Uninstall-BinFile dot
+Uninstall-BinFile circo
+Uninstall-BinFile sfdp
+Uninstall-BinFile twopi


### PR DESCRIPTION
## Description
Adding circo, sfdp, and twopi layout engines to dot

## Motivation and Context
Graphviz has many layout engines, and different ones are better suited to different graphs.

## How Has this Been Tested?
This simply duplicates an existing line for both installing and uninstalling.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

