### PR TITLE
(vcredist2017;vcredist140) Fixed 404 link for system requirements

### DIFF
--- a/automatic/vcredist140/README.md
+++ b/automatic/vcredist140/README.md
@@ -6,7 +6,7 @@ The Visual C++ Redistributable for Visual Studio 2017 consists of files vcruntim
 
 ## Notes
 
-[Supported Operating Systems](https://www.visualstudio.com/en-us/productinfo/vs2017-sysrequirements-vs): Windows 10, Windows 8.1 / Server 2012 R2 (with KB2919355), Windows 8 / Windows Server 2012, Windows 7 SP1 (with KB3033929) / Server 2008 R2 SP1, Windows Vista SP2 / Server 2008 SP2, Windows XP SP3 / Windows Server 2003 SP2
+[Supported Operating Systems](https://www.visualstudio.com/en-us/productinfo/vs2017-system-requirements-vs): Windows 10, Windows 8.1 / Server 2012 R2 (with KB2919355), Windows 8 / Windows Server 2012, Windows 7 SP1 (with KB3033929) / Server 2008 R2 SP1, Windows Vista SP2 / Server 2008 SP2, Windows XP SP3 / Windows Server 2003 SP2
 
 On some systems, if KB2999226 is installed as a dependency of this package, the computer may need to be restarted before the installation of this package will succeed.
 

--- a/automatic/vcredist2017/README.md
+++ b/automatic/vcredist2017/README.md
@@ -4,4 +4,4 @@ Microsoft Visual C++ Redistributable for Visual Studio 2017 installs run-time co
 
 ## Notes
 
-[Supported Operating Systems](https://www.visualstudio.com/en-us/productinfo/vs2017-sysrequirements-vs): Windows 10, Windows 8.1 / Server 2012 R2 (with KB2919355), Windows 8 / Windows Server 2012, Windows 7 SP1 (with KB3033929) / Server 2008 R2 SP1, Windows Vista SP2 / Server 2008 SP2, Windows XP SP3 / Windows Server 2003 SP2
+[Supported Operating Systems](https://www.visualstudio.com/en-us/productinfo/vs2017-system-requirements-vs): Windows 10, Windows 8.1 / Server 2012 R2 (with KB2919355), Windows 8 / Windows Server 2012, Windows 7 SP1 (with KB3033929) / Server 2008 R2 SP1, Windows Vista SP2 / Server 2008 SP2, Windows XP SP3 / Windows Server 2003 SP2


### PR DESCRIPTION
In the description an invalid link was found.

## Description
Replaced the invalid link with an valid link for both vcredist140 and vcredist2017.

## Motivation and Context
Fixes an invalid link

## How Has this Been Tested?
I verified that the link was working.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).