### PR TITLE
Brave fix icon urls

### DIFF
--- a/automatic/brave/brave.nuspec
+++ b/automatic/brave/brave.nuspec
@@ -16,8 +16,7 @@
 
 * This is an **official release version** of Brave. It is in continuous development with new releases landing approximately every three weeks. 
 ]]></description>
-    <!-- IconUrl: Skip check -->
-    <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages@a23ca30653/icons/brave.svg</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages/icons/brave.svg</iconUrl>
     <summary>A browser that lets you browse safer and faster by blocking ads and trackers.</summary>
     <owners>chocolatey, Sanshiro</owners>
     <authors>Brave Software Inc.</authors>

--- a/automatic/brave/update.ps1
+++ b/automatic/brave/update.ps1
@@ -18,14 +18,14 @@ function global:au_GetLatest {
                 URL64   = 'https://github.com' + $url64
                 Version = $version
                 Title   = 'Brave Browser'
-                IconUrl = 'https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages@a23ca30653/icons/brave.svg'
+                IconUrl = 'https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages/icons/brave.svg'
             }
            'beta' = @{
                 URL32   = 'https://github.com' + $url32_b
                 URL64   = 'https://github.com' + $url64_b
                 Version = $version_b + '-beta'
                 Title   = 'Brave Browser (Beta)'
-                IconUrl = 'https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages@a23ca30653/icons/brave-beta.svg'
+                IconUrl = 'https://cdn.jsdelivr.net/gh/chocolatey/chocolatey-coreteampackages/icons/brave-beta.svg'
            }
         }
     }


### PR DESCRIPTION
## Description
points jsdelivr to the right location for icon hosting 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
