### PR TITLE
(keepass-langfiles) Install language files into the correct folder

### DIFF
--- a/manual/keepass-langfiles/tools/chocolateyInstall.ps1
+++ b/manual/keepass-langfiles/tools/chocolateyInstall.ps1
@@ -26,4 +26,4 @@ if (-not (Test-Path $extractPath)) {
 }
 
 Get-ChocolateyUnzip $fileFullPath $extractPath
-Start-ChocolateyProcessAsAdmin "Copy-Item -Force '$extractPath\*.lngx' '$destination'"
+Start-ChocolateyProcessAsAdmin "Copy-Item -Force '$extractPath\*.lngx' '$destination\Languages\'"


### PR DESCRIPTION
.lngx files should go into Languages Folder. The Folder is created during KeePass installation, so there is no mkdir necessary.

Details see issue #1256

## Motivation and Context
Choosing your prefered language under View -> Change Language should just work.

## How Has this Been Tested?
1. Fresh built Win10 Client image
2. choco install -y keepass-langfiles
3. Above pulls keepass
4. Check if files are copied into correct folder
5. Check if View -> Change language works.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).

