### PR TITLE
(vcredist2008) restore environment after installing 32bit vcredist2008

### DIFF
--- a/manual/vcredist2008/tools/chocolateyInstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyInstall.ps1
@@ -14,4 +14,9 @@ Install-ChocolateyPackage @params
 
 # Install both 32bit and 64bit on a 64bit OS
 # If a program is compiled as x86 and the 32bit version of vcredist isn't installed, then the program would fail to start.
-if (Get-ProcessorBits 64) { $Env:chocolateyForceX86 = $true; Install-ChocolateyPackage @params }
+if (Get-ProcessorBits 64) { 
+  $originalChocolateyForceX86 = $Env:chocolateyForceX86
+  $Env:chocolateyForceX86 = $true
+  Install-ChocolateyPackage @params
+  $Env:chocolateyForceX86 = $originalChocolateyForceX86
+}


### PR DESCRIPTION
(vcredist2008) When this package is a dependency, it's install script sets the environment variable to force x86 installs.  So the dependent package then only installs the 32 bit version

## Description
Restore the original value of the environment variable that is being modified ($Env:chocolateyForceX86)

## Motivation and Context
this fixes the ability to install packages that depend on vcredist2008 and reliably get the x64 version installed

## How Has this Been Tested?
I used choco pack to build the vcredist2008 package (i added a description to the nuspec file)
I then created a chocolatey source with only my newly built vcredist2008 package and saltminion 2019.2
With my change, salt installs the x64 version.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
