### PR TITLE
(vscode) Move to user setup

### DIFF
--- a/automatic/vscode/update.ps1
+++ b/automatic/vscode/update.ps1
@@ -1,8 +1,8 @@
 import-module au
 import-module "$PSScriptRoot\..\..\extensions\chocolatey-core.extension\extensions\chocolatey-core.psm1"
 
-$releases32 = 'https://vscode-update.azurewebsites.net/api/update/win32/stable/VERSION'
-$releases64 = 'https://vscode-update.azurewebsites.net/api/update/win32-x64/stable/VERSION'
+$releases32 = 'https://vscode-update.azurewebsites.net/api/update/win32-user/stable/VERSION'
+$releases64 = 'https://vscode-update.azurewebsites.net/api/update/win32-x64-user/stable/VERSION'
 
 function global:au_SearchReplace {
     @{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
Since [1.26](https://code.visualstudio.com/updates/v1_26#_user-setup-for-windows), the default way to install visual studio code has been to use user-setup. This changes the way vscode is updated. In this way it no longer needs a UAC popup to update vscode. In this pull-request, the download link is changed to the 'user setup' version that enables it. The download url is now the same as the default windows download link on the vscode website.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
 - The json returned from both new urls is in the same format as the old ones

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

