### PR TITLE
(firefox) Break up Mozilla URL to avoid replacement by Package Internalizer

### DIFF
--- a/automatic/firefox/tools/helpers.ps1
+++ b/automatic/firefox/tools/helpers.ps1
@@ -43,7 +43,8 @@ function GetLocale {
   $systemLocalizeAndCountry = (Get-UICulture).Name
   $systemLocaleTwoLetter = (Get-UICulture).TwoLetterISOLanguageName
   Write-Verbose "System locale is: '$systemLocalizeAndCountry'..."
-  $Response = Invoke-WebRequest 'https://www.mozilla.org/' -UseBasicParsing -Headers @{'Accept-Language'=$systemLocalizeAndCountry} -MaximumRedirection 0 -ErrorAction Ignore
+  $urlParts = @( 'htt', 'mozilla' )
+  $Response = Invoke-WebRequest "$($urlParts[0])ps://www.$($urlParts[1]).org/" -UseBasicParsing -Headers @{'Accept-Language'=$systemLocalizeAndCountry} -MaximumRedirection 0 -ErrorAction Ignore
   $fallbackLocale = $Response.Headers.Location.Trim('/')
   Write-Verbose "Fallback locale is: '$fallbackLocale'..."
 


### PR DESCRIPTION
## Description
Package Internalizer would replace the URL https://mozilla.org that is used for detecting the locale, with code that points to the local file system. Breaking the URL up stops Package Internalizer from seeing it as a URL and replacing it.

## Motivation and Context
The [comment here](https://github.com/chocolatey-community/chocolatey-coreteampackages/pull/1698#issuecomment-933384062) indicated that internalizing the package breaks installation. Confirmed this in testing too.

## How Has this Been Tested?
1. Changes made and then package was created using `choco pack`.
2. Internalized the new package created above.
3. Checked the code in helpers.ps1 (that this PR amends) hadn't been replaced by Package Internalizer.
3. Installed the internalized package in a VM.

## Screenshot (if appropriate, usually isn't needed):

![image](https://user-images.githubusercontent.com/12760779/136244367-b83347a1-51ec-4646-a218-82c2f50df887.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).