### PR TITLE
(python3) Add NoLockdown parameter to not change permissions

### DIFF
--- a/automatic/python3/README.md
+++ b/automatic/python3/README.md
@@ -6,6 +6,7 @@ Python 3.x is a programming language that lets you work more quickly and integra
 
 - `/InstallDir` - Installation directory. **NOTE**: If you have pre-existing python3 installation, this parameter is ignored and existing python install location will be used
 - `/InstallDir32:` - Installation directory for 32bit python on 64bit Operating Systems. **NOTE**: Do only use this parameter if you wish to install 32bit python alongside 64bit python. 32Bit python will not be added on PATH.
+- `/NoLockdown` - Installation directory will not be locked down with Administrator only write permissions.
 
 Example: `choco install python3 --params "/InstallDir:C:\your\install\path"`
 

--- a/automatic/python3/python3.nuspec
+++ b/automatic/python3/python3.nuspec
@@ -16,6 +16,7 @@
 
 - `/InstallDir` - Installation directory. **NOTE**: If you have pre-existing python3 installation, this parameter is ignored and existing python install location will be used
 - `/InstallDir32:` - Installation directory for 32bit python on 64bit Operating Systems. **NOTE**: Do only use this parameter if you wish to install 32bit python alongside 64bit python. 32Bit python will not be added on PATH.
+- `/NoLockdown` - Installation directory will not be locked down with Administrator only write permissions.
 
 Example: `choco install python3 --params "/InstallDir:C:\your\install\path"`
 

--- a/automatic/python3/tools/chocolateyInstall.ps1
+++ b/automatic/python3/tools/chocolateyInstall.ps1
@@ -41,8 +41,13 @@ if (($Env:PYTHONHOME -ne $null) -and ($Env:PYTHONHOME -ne $InstallDir)) {
   Write-Warning "Environment variable PYTHONHOME points to different version: $Env:PYTHONHOME"
 }
 
-. "$toolsPath/helpers.ps1"
-Protect-InstallFolder `
-  -packageName "python3" `
-  -defaultInstallPath $defaultFolder `
-  -folder $installLocation
+if ($pp.NoLockdown) {
+  Write-Warning "NoLockdown parameter found. Not changing permissions. Please ensure your installation is secure."
+} else {
+  . "$toolsPath/helpers.ps1"
+  Protect-InstallFolder `
+    -packageName "python3" `
+    -defaultInstallPath $defaultFolder `
+    -folder $installLocation  
+}
+


### PR DESCRIPTION



<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description

This adds a "/NoLockdown" parameter to python3 to bypass the lockdown
of write permissions to administrators only.

It completely bypasses the `Protect-InstallFolder` helper function. 

Note added to the readme/description

## Motivation and Context

Fixes chocolatey-community/chocolatey-coreteampackages#1431
Related to chocolatey-community/chocolatey-coreteampackages#1547

## How Has this Been Tested?

1. Ran `update.ps1` with `IncludeStream` set to `3.10` to get a built package.
2. Installed in the test env without parameters to check it works as normal
3. Installed again in the test env with the nolockdown parameter to check that it works
4. Uninstall from the test environment
5. Installed on a windows 10 machine with the parameter

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).