### PR TITLE
(putty) Fixes putty.install x86 version

### DIFF
--- a/automatic/putty/update.ps1
+++ b/automatic/putty/update.ps1
@@ -14,7 +14,7 @@ function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
   #https://the.earth.li/~sgtatham/putty/latest/x86/putty-0.67-installer.msi
-  $url32Installer = $download_page.links | ? href -match '\.msi$' | ? href -notmatch '64bit' | select -First 1 -expand href
+  $url32Installer = $download_page.links | ? href -match '\.msi$' | ? href -notmatch '64bit|arm' | select -First 1 -expand href
   $url64Installer = $download_page.links | ? href -match '64bit.*\.msi$' | select -First 1 -expand href
 
   $version = $url32Installer -split '\-' | select -last 1 -skip 1


### PR DESCRIPTION
the arm64 is now available, so the x86 isn't always selected
with this change it should always be OK

## Description
-notmatch "64bit|arm" in place of -notmatch "64bit"

## Motivation and Context
x86 will work

## How Has this Been Tested?
powershell

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).