### PR TITLE
(freecad) Fix installer name

### DIFF
--- a/automatic/freecad/update_helper.ps1
+++ b/automatic/freecad/update_helper.ps1
@@ -7,7 +7,7 @@ function Get-FreeCad {
     [string]$uri = $releases
   )
   $download_page = Invoke-WebRequest -Uri $uri -UseBasicParsing
-  $mobile = @{$true = "portable"; $false = "installer" }[($kind -eq 'portable')]; $portable = @{$true = "vc(17|14)\.x\-x86(\-|_)64"; $false = "$mobile" }[($kind -eq 'dev')]
+  $mobile = @{$true = "portable1"; $false = "installer1" }[($kind -eq 'portable')]; $portable = @{$true = "vc(17|14)\.x\-x86(\-|_)64"; $false = "$mobile" }[($kind -eq 'dev')]
   $try = (($download_page.Links | ? href -match "CAD\-|\.[\dA-Z]+\-WIN" | select -First 1 -expand href).Split("/")[-1]).Split(".")[-1]
   $ext = @{$true = '7z'; $false = 'exe' }[( $kind -match 'dev' ) -or ( $portable -match 'portable' )]
   $re32 = "(WIN)\-x32\-($portable)\.$ext";


### PR DESCRIPTION
The github latest released added a "1" before the extension and the
download was not working.

Related #1648 and #1737 

<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->

The latest version available on Github features the following name `FreeCAD-0.19.2.7b5e18a-WIN-x64-installer1.exe`. This PR tries to account for the additional "1" in the installer name.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
I tested the install locally and FreeCAD gets downloaded as expected. 

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [ ] Issue 1 link
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey-community/chocolatey-packages/wiki/Package-migration-process) have been followed
