### PR TITLE
(googlechrome) Update chocolateyInstall.ps1

### DIFF
--- a/automatic/googlechrome/tools/chocolateyInstall.ps1
+++ b/automatic/googlechrome/tools/chocolateyInstall.ps1
@@ -10,8 +10,8 @@ if ($version -eq (Get-ChromeVersion)) {
 $packageArgs = @{
   packageName            = 'googlechrome'
   fileType               = 'MSI'
-  url                    = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'
-  url64bit               = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
+  url                    = 'https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi'
+  url64bit               = 'https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi'
   checksum               = '72ebc4f59405a5cb497d2fdd1e8989b07a1808ed0a43759802859ef351cf231d'
   checksum64             = 'f0a7e673d2da6da8005726c0a1e040bde7201241a5f760e99182c12b025698b2'
   checksumType           = 'sha256'


### PR DESCRIPTION
Fix Google Chrome Download Link

The google chrome download link has changed slightly, I fixed it so it will download reliably now.

## Description
I changed `https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi` to `https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi` removing the `tag/s/` part, as that has apparently changed.

## Motivation and Context
This fixes the chrome installer, as that is failing for my PCs I manage.

## How Has this Been Tested?
I don't fully know how to test this script, if someone can let me know, I will happily do whatever I need to.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
