### PR TITLE
(scribus) Switch to half-embedded

### DIFF
--- a/automatic/scribus/legal/VERIFICATION.txt
+++ b/automatic/scribus/legal/VERIFICATION.txt
@@ -7,15 +7,15 @@ location on <https://sourceforge.net/projects/scribus/files/scribus/>
 and can be verified by doing the following:
 
 1. Download the following:
-  32-Bit software: <https://sourceforge.net/projects/scribus/files/scribus/1.6.1/scribus-1.6.1-windows.exe/download>
-  64-Bit software: <https://sourceforge.net/projects/scribus/files/scribus/1.6.1/scribus-1.6.1-windows-x64.exe/download>
+  32-Bit software: NOT INCLUDED IN PACKAGE
+  64-Bit software: <https://sourceforge.net/projects/scribus/files/scribus/1.4.8/scribus-1.4.8-windows-x64.exe/download>
 2. Get the checksum using one of the following methods:
   - Using powershell function 'Get-FileHash'
   - Use chocolatey utility 'checksum.exe'
 3. The checksums should match the following:
 
   checksum type: sha256
-  checksum32: 82E7BED899524F2084F698F90FBFC41269C1D3B7C9F22EE8434866F0A51F1CFA
-  checksum64: 7EAA92581A8262A2F339B7CC4CB8982FA52454D27E6738E23EC14A66DB2A8FED
+  checksum32: NOT INCLUDED IN PACKAGE
+  checksum64: 1197587EBAF4622F348DA594F3D96442847024476F078B1C1B515A736A507181
 
 The file 'LICENSE.txt' has been obtained from <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>

--- a/automatic/scribus/tools/chocolateyInstall.ps1
+++ b/automatic/scribus/tools/chocolateyInstall.ps1
@@ -1,17 +1,24 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 
 $toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  file           = "$toolsPath\scribus-1.6.1-windows.exe"
-  file64         = "$toolsPath\scribus-1.6.1-windows-x64.exe"
+  url            = ''
+  checksum       = ''
+  checksumType   = 'sha256'
+  file64         = "$toolsPath\scribus-1.4.8-windows-x64.exe"
   softwareName   = 'Scribus*'
   silentArgs     = '/S'
   validExitCodes = @(0)
 }
 
-Install-ChocolateyInstallPackage @packageArgs
+if ((Get-OSArchitectureWidth -compare 32) -or ($env:chocolateyForceX86 -eq $true)) {
+  Install-ChocolateyPackage @packageArgs
+}
+else {
+  Install-ChocolateyInstallPackage @packageArgs
+}
 
 Get-ChildItem $toolsPath\*.exe | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" } }

--- a/automatic/scribus/update.ps1
+++ b/automatic/scribus/update.ps1
@@ -2,21 +2,23 @@
 
 $releases = 'https://sourceforge.net/projects/scribus/files/scribus/'
 
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix -FileNameSkip 1 }
+function global:au_BeforeUpdate {
+  Get-RemoteFiles -Purge -NoSuffix -FileNameSkip 1
+  Remove-Item "$PSScriptRoot\tools\$($Latest.FileName32)"
+}
 
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt"      = @{
       "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$releases>"
-      "(?i)(\s*32\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL32)>"
       "(?i)(\s*64\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL64)>"
-      "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType32)"
-      "(?i)(^\s*checksum(32)?\:).*"       = "`${1} $($Latest.Checksum32)"
+      "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType64)"
       "(?i)(^\s*checksum64\:).*"          = "`${1} $($Latest.Checksum64)"
     }
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*"   = "`${1}$($Latest.FileName32)`""
       "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
+      "(?i)(^\s*Url\s*=\s*)''"                    = "`${1}'$($Latest.URL32)'"
+      "(?i)(^\s*Checksum\s*=\s*)''"               = "`${1}'$($Latest.Checksum32)'"
     }
   }
 }


### PR DESCRIPTION
## Description

Switches scribus to be half embedded. If both installers are embedded, the package is over 200mb.

## Motivation and Context

Fixes #2397 

## How Has this Been Tested?
 
`update.ps1` tested on Windows 10, package tested in Chocolatey test env. 

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

