### PR TITLE
fix(freecad): update release name regex

### DIFF
--- a/automatic/freecad/update_helper.ps1
+++ b/automatic/freecad/update_helper.ps1
@@ -32,9 +32,8 @@ param(
     }
     'portable' {
       $download_page = (Get-GitHubRelease -Owner "Freecad" -Name "Freecad" -Verbose).assets
-      $mobile = "portable"
       $ext = "7z"
-      $re64 = "(FreeCAD\-)((\d+)?(\.))+?(\d)?(\-)(Windows)(\-)?(x\d{2})(\-|.)?(\d+)?(\.${ext})$"
+      $re64 = "(FreeCAD_)?((\d+)?(\.))+?(\d)?(\-conda)?(\-Windows)(\-|.)?(x\d{2}_\d{2}\-)?(py\d{2,5})?(\.${ext})$"
 #      $url64 = ( $download_page.Links | ? href -match $re64 | Sort-Object -Property 'href' -Descending | Select-Object -First 1 -ExpandProperty 'href' )
       $url64 = ( $download_page | Where-Object Name -match $re64 | Select-Object -First 1 -ExpandProperty 'browser_download_url' )
       $vert = "$version"
@@ -44,9 +43,8 @@ param(
     }
     'stable' {
       $download_page =  (Get-GitHubRelease -Owner "Freecad" -Name "Freecad" -Verbose).assets
-      $mobile = "installer"
       $ext = "exe"
-      $re64 = "(FreeCAD\-)((\d+)?(\.))+?(\d)?(\-)(WIN)(\-)?(x\d{2})\-(${mobile})(\-|.)?(\d+)?(\.${ext})$"
+      $re64 = "(FreeCAD_)?((\d+)?(\.))+?(\d)?(\-conda)?(\-Windows)(\-|.)?(x\d{2}_\d{2}\-)?(installer)?(\-|.)?(\d+)?(\.${ext})$"
 #      $url64 = ( $download_page.Links | ? href -match $re64 | Sort-Object -Property 'href' -Descending | Select-Object -First 1 -ExpandProperty 'href' )
       $url64 = ( $download_page | Where-Object Name -match $re64 | Select-Object -First 1 -ExpandProperty 'browser_download_url' )
       $vert = "$version"


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description

Match new names with v1:

- FreeCAD_1.0.0-conda-Windows-x86_64-installer-1.exe
- FreeCAD_1.0.0-conda-Windows-x86_64-py311.7z

## Motivation and Context

Missing update to v1.

## How Has this Been Tested?

Regex tester.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location

Release v1:
https://github.com/FreeCAD/FreeCAD/releases/tag/1.0.0