### PR TITLE
(ant-renamer) Fixes SourceForge Link in Update Script

### DIFF
--- a/automatic/ant-renamer/update.ps1
+++ b/automatic/ant-renamer/update.ps1
@@ -27,6 +27,11 @@ function global:au_GetLatest {
       $url = "$(([uri]$releases).Scheme)://$($url.TrimStart('https://'))"
     }
 
+    # SourceForge handles the linked /download page differently, so strip it.
+    if ($url.EndsWith("/download")) {
+      $url = $url -replace "/download$"
+    }
+
     $version  = [regex]::Match($download_page.Content, "Version\s+([0-9\.]+)").Groups[1].Value;
 
     return @{ URL32 = $url; Version = $version }


### PR DESCRIPTION
## Description
This change strips the '/download' from the URL if it's present, which allows the file to be downloaded successfully.

## Motivation and Context
The latest releases for ant-renamer are on SourceForge, and the linked url takes us to a download page rather than a direct link to the file.

## How Has this Been Tested?
- Built with update-all.ps1
- Installed on my test system
- Checked program had been installed
- Uninstalled on my test system

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
