### PR TITLE
(autoit) Fix Update Scripts

### DIFF
--- a/automatic/autoit.install/update.ps1
+++ b/automatic/autoit.install/update.ps1
@@ -29,11 +29,10 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  # BasicParsing is no option since we need to parse the version tag.
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-  $download_page.RawContent -match '\<td\>v([\d]+\.[\d\.]+)\<\/td\>' | Out-Null
-  $version = $Matches[1]
+  $download_page.RawContent -match '>Latest Version:.+\W?v(?<Version>[\d]+\.[\d\.]+)<' | Out-Null
+  $version = $Matches.Version
 
   $re = "setup\.zip$"
   $url = $download_page.links | Where-Object href -match $re | Select-Object -first 1 -expand href

--- a/automatic/autoit.portable/update.ps1
+++ b/automatic/autoit.portable/update.ps1
@@ -26,14 +26,12 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    # BasicParsing is no option since we need to parse the version tag.
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-    $download_page.RawContent -match '\<td\>v([\d]+\.[\d\.]+)\<\/td\>' | Out-Null
-    $version = $Matches[1]
+    $download_page.RawContent -match '>Latest Version:.+\W?v(?<Version>[\d]+\.[\d\.]+)<' | Out-Null
+    $version = $Matches.Version
 
-    $re = ".*zip$"
-    $url = $download_page.links | Where-Object href -match $re | Select-Object -first 1 -expand href
+    $url = $download_page.links.href.Where{"$_".EndsWith('.zip') -and $_ -notmatch '-setup'}
 
     $filename = $url -split '/' | Select-Object -Last 1
 


### PR DESCRIPTION
## Description

This commit updates the regex to select the current version from the current page layout.

## Motivation and Context

The previous versions were contained in a table. They are now not.

## How Has this Been Tested?

- Tested update of autoit*
- Tested install and uninstall of autoit* on my environment

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
