### PR TITLE
(nexus-repository) Patchfix Install Script with new URL

### DIFF
--- a/automatic/nexus-repository/_update.ps1
+++ b/automatic/nexus-repository/_update.ps1
@@ -6,8 +6,8 @@ function global:au_GetLatest {
 
   @{
     NexusVersion = $ReleaseVersion
-    Version      = $ReleaseVersion -replace '-', '.'
-    URL64        = "https://sonatype-download.global.ssl.fastly.net/repository/downloads-prod-group/3/nexus-$($ReleaseVersion)-win64.zip"
+    Version      = Get-FixVersion ($ReleaseVersion -replace '-', '.') -OnlyFixBelowVersion 3.71.1
+    URL64        = "https://download.sonatype.com/nexus/3/nexus-$($ReleaseVersion)-win64.zip"
   }
 }
 

--- a/automatic/nexus-repository/nexus-repository.nuspec
+++ b/automatic/nexus-repository/nexus-repository.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>nexus-repository</id>
     <title>Nexus Repository OSS</title>
-    <version>3.71.0.06</version>
+    <version>3.71.0.601</version>
     <authors>Sonatype</authors>
     <owners>chocolatey-community,DarwinJS</owners>
     <summary>Free open source version of popular Nexus Repository for binary artifacts including first class Nuget support.</summary>

--- a/automatic/nexus-repository/tools/chocolateyinstall.ps1
+++ b/automatic/nexus-repository/tools/chocolateyinstall.ps1
@@ -55,7 +55,7 @@ if (Test-Path "$ExtractFolder") {
 $PackageArgs = @{
   packageName    = $env:ChocolateyPackageName
   unzipLocation  = $ExtractFolder
-  url64          = 'https://sonatype-download.global.ssl.fastly.net/repository/downloads-prod-group/3/nexus-3.71.0-06-win64.zip'
+  url64          = 'https://download.sonatype.com/nexus/3/nexus-3.71.0-06-win64.zip'
   checksum64     = '39836efac22c82819b48951c7a489853c6dc21ce86b62660a84c14ef944117f5'
   checksumType64 = 'SHA256'
 }


### PR DESCRIPTION
## Description

This updates the existing version to a working URL, and uses the package fix notation for anything below the next patch version.

## Motivation and Context

Sonatype have moved their download URL from fastly to something else.

This breaks existing packages, and as apparently our package cacher did not run against this, all customers and users alike.

As this update is currently in the disabled state (due to previous issues), we cannot simply let it fix itself, and need to manually fix it.


## How Has this Been Tested?

- Tried to install existing package, failed with or without license.
- Packed package and installed it on a sandbox.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
