### PR TITLE
(maint) Bump Chocolatey version for CI and templates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,8 +42,8 @@ environment:
     secure: zPuYvdxGda6DUGRCwTJL5FQCWF3U+1bSLE2mEr+VfpfV08NXlXX2uFLizkhQuJYW
 
   #Chocolatey version we want to use when checking for updates (usually latest).
-  choco_version: '2.5.1'
-  choco_version_pr: '2.3.0'
+  choco_version: '2.6.0'
+  choco_version_pr: '2.4.0'
   nupkg_cache_path: C:\packages
 
 init:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,13 +26,13 @@ body:
         Do mind that versions older than the latest version that was available 1 year ago will not be supported.
       multiple: true
       options:
+        - 2.6.0
         - 2.5.1
         - 2.5.0
         - 2.4.3
         - 2.4.2
         - 2.4.1
         - 2.4.0
-        - 2.3.0
         - Other (note in the comments)
     validations:
       required: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
- Bumped Chocolatey version references to 2.6.0 across CI configuration and issue template.
- Set appveyor.yml choco_version to 2.6.0 and choco_version_pr to 2.4.0.
- Added 2.6.0 as an option in the bug report issue template.

## Motivation and Context
- Ensure CI uses a current Chocolatey release for update checks.
- Keep issue reporting options aligned with supported/testable package versions.

## How Has this Been Tested?
- N/A (configuration and template changes; intended to affect subsequent CI runs and issue reporting)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).