### PR TITLE
(sysinternals) Remove file checksum checks to avoid breakage

### DIFF
--- a/automatic/sysinternals/tools/chocolateyInstall.ps1
+++ b/automatic/sysinternals/tools/chocolateyInstall.ps1
@@ -9,8 +9,6 @@ Write-Host "Sysinternals Suite is going to be installed in '$installDir'"
 $packageArgs = @{
   packageName    = 'sysinternals'
   url            = 'https://download.sysinternals.com/files/SysinternalsSuite.zip'
-  checksum       = 'ba441238eb68b33aa7b9abf141ee9bc5393dfce2e174135095b898840b0b6c58'
-  checksumType   = 'sha256'
   unzipLocation  = $installDir
 }
 Install-ChocolateyZipPackage @packageArgs
@@ -18,7 +16,6 @@ Accept-Eula
 if ($installDir -ne $toolsPath) { Install-ChocolateyPath $installDir }
 if (Is-NanoServer) {
   $packageArgs.url = 'https://download.sysinternals.com/files/SysinternalsSuite-Nano.zip'
-  $packageArgs.checksum = '629befc53ce594d5266be99aad521700c012ac36ff2784527dfb68734ac0b963'
  }
 
 $old_path = 'c:\sysinternals'


### PR DESCRIPTION
Fixes #2751. The SHA256 file checks here are problematic, since they're based on URLs that point to the latest version of `SysinternalsSuite` & `SysinternalsSuite-Nano`. This means that the script will break every time a new `SysinternalsSuite` version is released.

Proposing to remove the SHA256 file checks to avoid problems like #2751 moving forward. A better solution would be to instead download `SysinternalsSuite` from version-specific URLs. However, I've been unable to find any such URLs on https://learn.microsoft.com/nb-no/sysinternals/downloads/