### PR TITLE
(keepassxc) update hash parsing logic

### DIFF
--- a/automatic/keepassxc/update.ps1
+++ b/automatic/keepassxc/update.ps1
@@ -33,7 +33,7 @@ function Get-Hash($url, $filename) {
   $downloadedPage = $downloadedPage.Split([Environment]::NewLine)
   foreach ($line in $downloadedPage) {
     $parsed = $line -split ' |\n' -replace '\*', ''
-    if ($parsed[1] -Match $filename) {
+    if ($parsed[-1] -Match $filename) {
       return $parsed[0]
     }
   }


### PR DESCRIPTION
## Description
Update hash parsing logic to correctly parse DIGEST file for hash and filename components

## Motivation and Context
In certain releases, the DIGEST file contains multiple spaces between hash and filename, causing the parsing logic to fail.
See: 
- 2.7.11 (multiple spaces): https://github.com/keepassxreboot/keepassxc/releases/download/2.7.11/KeePassXC-2.7.11-Win64.msi.DIGEST
- 2.7.10 (single space): https://github.com/keepassxreboot/keepassxc/releases/download/2.7.10/KeePassXC-2.7.10-Win64.msi.DIGEST

## How Has this Been Tested?

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
