### PR TITLE
[vscode.install] Exit package install when pkg_version <= installed_version

### DIFF
--- a/automatic/vscode.install/tools/ChocolateyInstall.ps1
+++ b/automatic/vscode.install/tools/ChocolateyInstall.ps1
@@ -5,8 +5,8 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $softwareName = 'Microsoft Visual Studio Code'
 $version = '1.107.1'
-if ($version -eq (Get-UninstallRegistryKey "$softwareName").DisplayVersion) {
-  Write-Host "VS Code $version is already installed."
+if ($version -le (Get-UninstallRegistryKey "$softwareName").DisplayVersion) {
+  Write-Host "VS Code $version (or newer) is already installed."
   return
 }
 


### PR DESCRIPTION
## Description
The package, as it is in chocolatey, exits without installing whenever the package version is equal to the installed version.

But this means that it's possible for the package to perform a downgrade. For instance, if the user were to run use vscode's own upgrade mechanism then try to upgrade through chocolately.

By having it return when ($version -le (Get-UninstallRegistryKey "$softwareName").DisplayVersion) This ensures that chocolatey will exit whenever the package version is equal or lower than the installed version. This ensures that it won't perform a downgrade.

## Motivation and Context
This makes it so that the package will no longer potentially perform package downgrade.
It will exit with success both when the package version is installed and when a newer version is installed.

## How Has this Been Tested?
I tested this by
1) Installing package version 1.106.3
2) Upgraded to version 1.107.1 through vscode itself
3) Downloading the 1.107.0 nupkg from chocolatey
4) Opened the nupkg and change tools/ChocolateyInstall.ps1 to use the same code shown
5) ran choco.exe upgrade vscode.install -s '.' --params "/NoDesktopIcon"
6) See that it skips upgrade

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [ ] Issue 1 link
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey-community/chocolatey-packages/wiki/Package-migration-process) have been followed

```
> choco.exe upgrade vscode.install -s '.' --params "/NoDesktopIcon"
Chocolatey v2.6.0
3 validations performed. 2 success(es), 1 warning(s), and 0 error(s).

Validation Warnings:
 - A pending system reboot request has been detected, however, this is
   being ignored due to the current Chocolatey configuration.  If you
   want to halt when this occurs, then either set the global feature
   using:
     choco feature enable --name="exitOnRebootDetected"
   or pass the option --exit-when-reboot-detected.

Upgrading the following packages:
vscode.install
By upgrading, you accept licenses for the packages.
vscode.install v1.107.0 is the latest version available based on your source(s).

Chocolatey upgraded 0/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```