### PR TITLE
Update PHP releases and download URLs in update.ps1

### DIFF
--- a/automatic/php/update.ps1
+++ b/automatic/php/update.ps1
@@ -1,6 +1,7 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'http://windows.php.net/download'
+# Define the releases URL to get the latest PHP versions. It was updated to use the new path.
+$releases = 'https://downloads.php.net/~windows/releases/'
 
 function global:au_BeforeUpdate {
   Remove-Item -Recurse -Force "$PSScriptRoot\tools\*.zip"
@@ -69,15 +70,16 @@ function Get-Dependency() {
   return $result
 }
 
+# Base download URL uses the $releases variable since all downloads are now under that path.
 function CreateStream {
   param([uri]$url32Bit, [uri]$url64bit, [version]$version)
 
   $Result = @{
     Version      = $version
-    URLNTS32     = 'http://windows.php.net' + $url32bit
-    URLNTS64     = 'http://windows.php.net' + $url64bit
-    URLTS32      = 'http://windows.php.net' + ($url32bit | ForEach-Object { $_ -replace '\-nts', '' })
-    URLTS64      = 'http://windows.php.net' + ($url64bit | ForEach-Object { $_ -replace '\-nts', '' })
+    URLNTS32     = $releases + $url32bit
+    URLNTS64     = $releases + $url64bit
+    URLTS32      = $releases + ($url32bit | ForEach-Object { $_ -replace '\-nts', '' })
+    URLTS64      = $releases + ($url64bit | ForEach-Object { $_ -replace '\-nts', '' })
     ReleaseNotes = "https://www.php.net/ChangeLog-$($version.Major).php#${version}"
     Dependency   = Get-Dependency $url32Bit
   }


### PR DESCRIPTION
Changed the releases URL to the new PHP downloads path and updated all download URL constructions to use the new base. This ensures compatibility with the latest PHP Windows release structure.

<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description

- PHP moved Windows binaries from windows.php.net to downloads.php.net.

- This updates the PHP automatic update script to scrape: https://downloads.php.net/~windows/releases/
And build download URLs from that location.

- Fixes #2769


## Motivation and Context

- The automatic/php/update.ps1 script was scraping http://windows.php.net/download and constructing download URLs using windows.php.net.

- That location no longer provides the releases listing, which prevents AU from detecting the latest PHP versions.

- Updating the scrape URL and the base URL restores automatic updates for current PHP Windows releases.

## How Has this Been Tested?

- Ran automatic/php/update.ps1 from PowerShell.
- Confirmed au_GetLatest detects the latest versions present in the releases index (8.5.2, 8.4.17, 8.3.30, 8.2.30).
- Confirmed the generated download URLs point to downloads.php.net/~windows/releases/ and downloads complete in au_BeforeUpdate (ZIP files retrieved and checksums computed).
- Confirmed streams are rebuilt and package update completes successfully.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My pull request is not coming from the master branch.
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).