### PR TITLE
(selenium-chromium-edge-driver) Update URL for msedgedriver LATEST_STABLE info. Fixes #2787

### DIFF
--- a/automatic/selenium-chromium-edge-driver/update.ps1
+++ b/automatic/selenium-chromium-edge-driver/update.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = "https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/LATEST_STABLE"
+$releases = "https://msedgedriver.microsoft.com/LATEST_STABLE"
 
 function global:au_BeforeUpdate {
   $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32 -Algorithm $Latest.ChecksumType32


### PR DESCRIPTION
## Description
Updates the URL used to load the version identifier for the latest available stable version of the MS edge webdriver.

## Motivation and Context
Fixes #2787 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).