### PR TITLE
(gitextensions) use x64 binaries and bump the dependencies

### DIFF
--- a/automatic/gitextensions/gitextensions.nuspec
+++ b/automatic/gitextensions/gitextensions.nuspec
@@ -45,9 +45,9 @@
     <mailingListUrl>http://groups.google.com/group/gitextensions</mailingListUrl>
     <bugTrackerUrl>http://github.com/gitextensions/gitextensions/issues</bugTrackerUrl>
     <dependencies>
-      <dependency id="git" version="2.51.0" />
+      <dependency id="git" version="2.54.0" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="dotnet-9.0-desktopruntime" version="9.0.11" />
+      <dependency id="dotnet-10.0-desktopruntime" version="10.0.9" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/gitextensions/legal/VERIFICATION.txt
+++ b/automatic/gitextensions/legal/VERIFICATION.txt
@@ -5,12 +5,12 @@ in verifying that this package's contents are trustworthy.
 The installer has been downloaded from GitHub and can be verified like this:
 
 1. Download the following installers:
-  url: <https://github.com/gitextensions/gitextensions/releases/download/v7.0.1/GitExtensions-arm64-7.0.1.86-c119a52.msi>
+  url: <https://github.com/gitextensions/gitextensions/releases/download/v7.0.1/GitExtensions-x64-7.0.1.86-c119a52.msi>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum: AE43D20724223F0A29404AE707B1B2AE3B24464094148B9F7505619CE41F362B
+  checksum: 53792D2BF39E0949319CA711A189120E41D53B60D7B74D6A11D66120CD0725ED
 
 The included license file have been downloaded from <https://github.com/gitextensions/gitextensions/blob/0a4730ccdf7e36c0078813101a3ee70e825e93ec/LICENSE.md>

--- a/automatic/gitextensions/tools/chocolateyInstall.ps1
+++ b/automatic/gitextensions/tools/chocolateyInstall.ps1
@@ -6,7 +6,7 @@ $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
     softwareName   = 'Git Extensions*'
     fileType       = 'msi'
-    file           = "$toolsDir\GitExtensions-arm64-7.0.1.86-c119a52.msi"
+    file           = "$toolsDir\GitExtensions-x64-7.0.1.86-c119a52.msi"
     silentArgs     = '/quiet /norestart ADDDEFAULT=ALL REMOVE=AddToPath'
     validExitCodes = @(0, 3010, 1641)
 }

--- a/automatic/gitextensions/update.ps1
+++ b/automatic/gitextensions/update.ps1
@@ -21,10 +21,10 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $LatestRelease = Get-GitHubRelease -Owner "gitextensions" -Name "gitextensions"
 
-  $re = 'GitExtensions-(.+)\.msi$'
+  $re = 'GitExtensions-x64-(.+)\.msi$'
   $downloadUrl = $LatestRelease.assets.browser_download_url | Where-Object { $_ -match $re } | Select-Object -First 1
   $releaseUrl = $LatestRelease.html_url
-  
+
   $version = ($downloadUrl -split '\/' | Select-Object -last 1 -skip 1).Substring(1)
 
   $version = $version -replace ".RC", "-RC"
@@ -42,12 +42,12 @@ function global:au_GetLatest {
   }
 
   $version = $version + $pre
-  
+
   $version = Get-Version $version
 
   return @{
     Version        = $version
-    URL32          = $downloadUrl 
+    URL32          = $downloadUrl
     ReleaseURL     = $releaseUrl
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description

Update the gitextensions package to switchback to use the x64 binaries (they were switched by the latest automatic update).

Also bump the dependencies to match the newer 7.x requirements.

Please, force a new build of the package, because its currently broken.

## Motivation and Context

Update the gitextensions package to switchback to use the x64 binaries (they were switched by the latest automatic update).

Also bump the dependencies to match the newer 7.x requirements.

## How Has this Been Tested?

The package was updated using:

```powershell
.\update_all.ps1 -ForcedPackage gitextensions -Name gitextensions
```

Then, it was installed locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
