### PR TITLE
(googlechrome) derive version from downloaded MSI artifact

### DIFF
--- a/automatic/googlechrome/update.ps1
+++ b/automatic/googlechrome/update.ps1
@@ -4,9 +4,106 @@ import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 $releases = "https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions"
 $paddedUnderVersion = '57.0.2988'
 
+function Get-MsiProductVersion {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$MsiPath
+  )
+
+  $installer = $null
+  $database = $null
+  $view = $null
+  $record = $null
+
+  try {
+    $installer = New-Object -ComObject WindowsInstaller.Installer
+    $database = $installer.GetType().InvokeMember(
+      'OpenDatabase',
+      [System.Reflection.BindingFlags]::InvokeMethod,
+      $null,
+      $installer,
+      @($MsiPath, 0)
+    )
+    $view = $database.GetType().InvokeMember(
+      'OpenView',
+      [System.Reflection.BindingFlags]::InvokeMethod,
+      $null,
+      $database,
+      @("SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'")
+    )
+    $null = $view.GetType().InvokeMember(
+      'Execute',
+      [System.Reflection.BindingFlags]::InvokeMethod,
+      $null,
+      $view,
+      $null
+    )
+    $record = $view.GetType().InvokeMember(
+      'Fetch',
+      [System.Reflection.BindingFlags]::InvokeMethod,
+      $null,
+      $view,
+      $null
+    )
+
+    if ($null -eq $record) {
+      throw "Could not read ProductVersion from '$MsiPath'."
+    }
+
+    $productVersion = $record.GetType().InvokeMember(
+      'StringData',
+      [System.Reflection.BindingFlags]::GetProperty,
+      $null,
+      $record,
+      @(1)
+    )
+
+    if ([string]::IsNullOrWhiteSpace($productVersion)) {
+      throw "MSI ProductVersion is empty for '$MsiPath'."
+    }
+
+    return $productVersion
+  }
+  finally {
+    foreach ($comObject in @($record, $view, $database, $installer)) {
+      if ($null -ne $comObject -and [System.Runtime.InteropServices.Marshal]::IsComObject($comObject)) {
+        [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($comObject)
+      }
+    }
+  }
+}
+
+function Get-FileSha256 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  (Get-FileHash -Path $Path -Algorithm SHA256).Hash
+}
+
 function global:au_BeforeUpdate {
-  $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32
-  $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64
+  $downloadPath32 = Join-Path $env:TEMP "googlechrome32-$PID.msi"
+  $downloadPath64 = Join-Path $env:TEMP "googlechrome64-$PID.msi"
+
+  try {
+    Invoke-WebRequest -UseBasicParsing -Method Get -Uri $Latest.URL64 -OutFile $downloadPath64
+    $msiVersion = Get-MsiProductVersion -MsiPath $downloadPath64
+
+    if ($Latest.RemoteVersion -ne $msiVersion) {
+      throw "Version mismatch: API returned '$($Latest.RemoteVersion)' but MSI contains '$msiVersion'."
+    }
+
+    $Latest.RemoteVersion = $msiVersion
+    $Latest.Checksum64 = Get-FileSha256 -Path $downloadPath64
+
+    Invoke-WebRequest -UseBasicParsing -Method Get -Uri $Latest.URL32 -OutFile $downloadPath32
+    $Latest.Checksum32 = Get-FileSha256 -Path $downloadPath32
+  }
+  finally {
+    Remove-Item -Path $downloadPath32 -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $downloadPath64 -Force -ErrorAction SilentlyContinue
+  }
 }
 
 function global:au_SearchReplace {


### PR DESCRIPTION
## Description
Update `automatic/googlechrome` AU flow to download the MSI first, extract `ProductVersion` from MSI metadata, and compute checksums from the downloaded artifacts.

## Motivation and Context
The Chrome enterprise MSI URL is rolling and can drift from API-reported version data. Verifying version from the actual downloaded MSI avoids publishing metadata based on a different artifact than the one hashed.

## How Has this Been Tested?
Local AU test runs were executed in the fork.
A fail-fast mismatch path was observed with live data, and a controlled aligned run verified that nuspec and chocolateyInstall values are updated consistently.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
