### PR TITLE
jubler: update to 10.0.0

### DIFF
--- a/automatic/jubler/Changelog.md
+++ b/automatic/jubler/Changelog.md
@@ -7,7 +7,7 @@
 - **ENHANCEMENT:** Updated to Jubler 10.0.0.
 - Automatic updates now track the project's GitHub release page instead of the retired jubler.org site.
 - The package now downloads the official self-contained x64 installer at install time; the Java runtime and media-player dependencies are no longer required.
-- Silent install and uninstall arguments updated for the current Inno Setup based installer.
+- Silent install and uninstall arguments updated for the current Inno Setup-based installer.
 - Updated package metadata to the current software sources.
 
 ## Version: 5.1.0.20170608 (2017-06-08)

--- a/automatic/jubler/Changelog.md
+++ b/automatic/jubler/Changelog.md
@@ -2,9 +2,13 @@
 
 ## UPCOMING
 
-- Updated package metadata to latest software sources.
-- **BUG:** Incorrect variable using in warning message for uninstall script.
-- **BUG:** Valid exit codes incorrectly used in uninstall script.
+## Version: 10.0.0 (2026-07-31)
+
+- **ENHANCEMENT:** Updated to Jubler 10.0.0.
+- Automatic updates now track the project's GitHub release page instead of the retired jubler.org site.
+- The package now downloads the official self-contained x64 installer at install time; the Java runtime and media-player dependencies are no longer required.
+- Silent install and uninstall arguments updated for the current Inno Setup based installer.
+- Updated package metadata to the current software sources.
 
 ## Version: 5.1.0.20170608 (2017-06-08)
 

--- a/automatic/jubler/Readme.md
+++ b/automatic/jubler/Readme.md
@@ -9,12 +9,12 @@ Jubler is a tool to edit text-based subtitles. It can be used as an authoring so
 * GUI internationalization support through gettext utilities.
 * Styles are supported (when saving in SubStation formats). These styles are specific per subtitle or per character.
 * Translating mode (parent & child editors) is supported
-* Graphical preview of subtitles using the FFMPEG library. Current frame, waveform preview and waveform listening is supported.
+* Graphical preview of subtitles using VLC. Current frame, waveform preview and waveform listening is supported.
 * Graphical display of subtitles, which can be moved and resized.
-* Test and play the subtitles file using a video player (mplayer). While in playing mode the user is able to freely edit the subtitles (and inform the player of this change), add a new subtitle in real time or synchonize subtitles with the movie.
+* Test and play the subtitles file using an integrated video player (VLC). While in playing mode the user is able to freely edit the subtitles (and inform the player of this change), add a new subtitle in real time or synchonize subtitles with the movie.
 * Mark subtitles with different colors, either when editing or real time when playing the video.
 * Spell checking, with support for dictionary selection.
-* Easy installation for Mac, Linux & Windows platforms and a generic installer for all other platforms (without FFMPEG support).
+* Easy installation for Mac, Linux & Windows platforms and a generic installer for all other platforms.
 * Auto update application.
 
 ### Key editing features

--- a/automatic/jubler/Readme.md
+++ b/automatic/jubler/Readme.md
@@ -11,7 +11,7 @@ Jubler is a tool to edit text-based subtitles. It can be used as an authoring so
 * Translating mode (parent & child editors) is supported
 * Graphical preview of subtitles using VLC. Current frame, waveform preview and waveform listening is supported.
 * Graphical display of subtitles, which can be moved and resized.
-* Test and play the subtitles file using an integrated video player (VLC). While in playing mode the user is able to freely edit the subtitles (and inform the player of this change), add a new subtitle in real time or synchonize subtitles with the movie.
+* Test and play the subtitles file using an integrated video player (VLC). While in playing mode the user is able to freely edit the subtitles (and inform the player of this change), add a new subtitle in real time or synchronize subtitles with the movie.
 * Mark subtitles with different colors, either when editing or real time when playing the video.
 * Spell checking, with support for dictionary selection.
 * Easy installation for Mac, Linux & Windows platforms and a generic installer for all other platforms.

--- a/automatic/jubler/jubler.nuspec
+++ b/automatic/jubler/jubler.nuspec
@@ -29,7 +29,7 @@ Jubler is a tool to edit text-based subtitles. It can be used as an authoring so
 * Translating mode (parent & child editors) is supported
 * Graphical preview of subtitles using VLC. Current frame, waveform preview and waveform listening is supported.
 * Graphical display of subtitles, which can be moved and resized.
-* Test and play the subtitles file using an integrated video player (VLC). While in playing mode the user is able to freely edit the subtitles (and inform the player of this change), add a new subtitle in real time or synchonize subtitles with the movie.
+* Test and play the subtitles file using an integrated video player (VLC). While in playing mode the user is able to freely edit the subtitles (and inform the player of this change), add a new subtitle in real time or synchronize subtitles with the movie.
 * Mark subtitles with different colors, either when editing or real time when playing the video.
 * Spell checking, with support for dictionary selection.
 * Easy installation for Mac, Linux & Windows platforms and a generic installer for all other platforms.

--- a/automatic/jubler/jubler.nuspec
+++ b/automatic/jubler/jubler.nuspec
@@ -3,15 +3,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jubler</id>
-    <version>8.0.0</version>
+    <version>10.0.0</version>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/jubler</packageSourceUrl>
     <owners>chocolatey-community, AdmiringWorm</owners>
     <title>Jubler Subtitle Editor</title>
     <authors>Panayotis Katsaloulis</authors>
-    <projectUrl>http://www.jubler.org/index.html</projectUrl>
+    <projectUrl>https://github.com/teras/Jubler</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@a8fa14d8c3ca49fd8bd8f856d9091b1a9103ada1/icons/jubler.png</iconUrl>
-    <copyright>(C) 2005-2018 Panayotis Katsaloulis</copyright>
-    <licenseUrl>https://github.com/teras/Jubler/blob/master/LICENCE</licenseUrl>
+    <copyright>(C) 2005-2026 Panayotis Katsaloulis</copyright>
+    <licenseUrl>https://github.com/teras/Jubler/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/teras/Jubler</projectSourceUrl>
     <bugTrackerUrl>https://github.com/teras/Jubler/issues</bugTrackerUrl>
@@ -27,12 +27,12 @@ Jubler is a tool to edit text-based subtitles. It can be used as an authoring so
 * GUI internationalization support through gettext utilities.
 * Styles are supported (when saving in SubStation formats). These styles are specific per subtitle or per character.
 * Translating mode (parent & child editors) is supported
-* Graphical preview of subtitles using the FFMPEG library. Current frame, waveform preview and waveform listening is supported.
+* Graphical preview of subtitles using VLC. Current frame, waveform preview and waveform listening is supported.
 * Graphical display of subtitles, which can be moved and resized.
-* Test and play the subtitles file using a video player (mplayer). While in playing mode the user is able to freely edit the subtitles (and inform the player of this change), add a new subtitle in real time or synchonize subtitles with the movie.
+* Test and play the subtitles file using an integrated video player (VLC). While in playing mode the user is able to freely edit the subtitles (and inform the player of this change), add a new subtitle in real time or synchonize subtitles with the movie.
 * Mark subtitles with different colors, either when editing or real time when playing the video.
 * Spell checking, with support for dictionary selection.
-* Easy installation for Mac, Linux & Windows platforms and a generic installer for all other platforms (without FFMPEG support).
+* Easy installation for Mac, Linux & Windows platforms and a generic installer for all other platforms.
 * Auto update application.
 
 ### Key editing features
@@ -48,14 +48,9 @@ Jubler is a tool to edit text-based subtitles. It can be used as an authoring so
 
 ]]></description>
     <releaseNotes>
-[Software Changelog](http://www.jubler.org/changelog.html)
-[Package Changelog](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/automatic/jubler/Changelog.md)
+[Software Changelog](https://github.com/teras/Jubler/releases)
+[Package Changelog](https://github.com/chocolatey-community/chocolatey-packages/blob/master/automatic/jubler/Changelog.md)
     </releaseNotes>
-    <dependencies>
-      <dependency id="javaruntime" version="8.0" />
-      <dependency id="smplayer" version="16.8.0" />
-      <dependency id="chocolatey-core.extension" version="1.3.3" />
-    </dependencies>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/jubler/jubler.nuspec
+++ b/automatic/jubler/jubler.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jubler</id>
-    <version>10.0.0</version>
+    <version>8.0.0</version>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/jubler</packageSourceUrl>
     <owners>chocolatey-community, AdmiringWorm</owners>
     <title>Jubler Subtitle Editor</title>

--- a/automatic/jubler/legal/VERIFICATION.txt
+++ b/automatic/jubler/legal/VERIFICATION.txt
@@ -2,20 +2,19 @@ VERIFICATION
 Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
-The embedded software have been downloaded from the listed download
-location on <http://www.jubler.org/download.html>
-and can be verified by doing the following:
+This package downloads the official installer from the author's GitHub
+release page:
+
+  Download location: <https://github.com/teras/Jubler/releases>
 
 1. Download the following:
-  32-Bit software: <https://github.com/teras/Jubler/releases/download/v7.0.3/Jubler-7.0.3.x32.exe>
-  64-Bit software: <https://github.com/teras/Jubler/releases/download/v8.0.0/Jubler-8.0.0.x64.exe>
+  64-Bit software: <https://github.com/teras/Jubler/releases/download/v10.0.0/Jubler-10.0.0-x64.exe>
 2. Get the checksum using one of the following methods:
   - Using powershell function 'Get-FileHash'
   - Use chocolatey utility 'checksum.exe'
-3. The checksums should match the following:
+3. The checksum should match the following:
 
   checksum type: sha256
-  checksum32: D87DC5CCBADAD1EF277D0069F4951C9DCC06DF1F0AB5AD496FCAFC20CF6E8613
-  checksum64: B67B7EB6AD94F3367F76C05CDC8AAE08185F022C2F616B094719EC8969E75933
+  checksum: CF8729148E2CE4A184CF5E0D953A43E20CA514CB7E3E2BDE17A8A0A6BCBAA1B2
 
-The file 'LICENSE.txt' has been obtained from <https://sourceforge.net/p/jubler/code/ci/jubler/tree/LICENCE?format=raw>
+The file 'LICENSE.txt' has been obtained from <https://github.com/teras/Jubler/blob/master/LICENSE>

--- a/automatic/jubler/tools/chocolateyinstall.ps1
+++ b/automatic/jubler/tools/chocolateyinstall.ps1
@@ -1,17 +1,14 @@
-﻿$ErrorActionPreference = 'Stop';
-
-$toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$ErrorActionPreference = 'Stop'
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  file           = "$toolsPath\Jubler-7.0.3.x32.exe"
-  file64         = "$toolsPath\Jubler-8.0.0.x64.exe"
-  softwareName   = 'Jubler subtitle editor'
-  silentArgs     = '/S'
+  url64bit       = 'https://github.com/teras/Jubler/releases/download/v10.0.0/Jubler-10.0.0-x64.exe'
+  checksum64     = 'CF8729148E2CE4A184CF5E0D953A43E20CA514CB7E3E2BDE17A8A0A6BCBAA1B2'
+  checksumType64 = 'sha256'
+  softwareName   = 'Jubler*'
+  silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
   validExitCodes = @(0)
 }
 
-Install-ChocolateyInstallPackage @packageArgs
-
-Remove-Item -Force -ea 0 "$toolsPath\*.exe","$toolsPath\*.ignore"
+Install-ChocolateyPackage @packageArgs

--- a/automatic/jubler/tools/chocolateyuninstall.ps1
+++ b/automatic/jubler/tools/chocolateyuninstall.ps1
@@ -1,10 +1,10 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  softwareName  = 'Jubler subtitle editor'
+  softwareName  = 'Jubler*'
   fileType      = 'exe'
-  silentArgs    = '/S'
+  silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
   validExitCodes= @(0)
 }
 

--- a/automatic/jubler/update.ps1
+++ b/automatic/jubler/update.ps1
@@ -1,8 +1,6 @@
 Import-Module Chocolatey-AU
 Import-Module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'https://github.com/teras/Jubler/releases/latest'
-
 function global:au_AfterUpdate {
   Update-ChangelogVersion -version $Latest.Version
 }
@@ -23,17 +21,14 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $release = Get-GitHubRelease -Owner 'teras' -Name 'Jubler'
 
-  $re  = 'Jubler-.*-x64\.exe$'
-  $url = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href
-  if ($url -notmatch '^https?://') { $url = 'https://github.com' + $url }
-
-  if ($url -match 'Jubler-([\d.]+)-x64\.exe') { $version = $Matches[1] }
+  $asset = $release.assets | Where-Object name -match 'Jubler-.*-x64\.exe$' | Select-Object -First 1
+  if (-not $asset) { throw "No x64 installer asset found in the latest Jubler release." }
 
   @{
-    URL64    = $url
-    Version  = $version
+    URL64    = $asset.browser_download_url
+    Version  = $release.tag_name -replace '^v', ''
     FileType = 'exe'
   }
 }

--- a/automatic/jubler/update.ps1
+++ b/automatic/jubler/update.ps1
@@ -1,10 +1,7 @@
-﻿Import-Module Chocolatey-AU
+Import-Module Chocolatey-AU
 Import-Module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'http://www.jubler.org/download.html'
-$softwareName = 'Jubler subtitle editor'
-
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
+$releases = 'https://github.com/teras/Jubler/releases/latest'
 
 function global:au_AfterUpdate {
   Update-ChangelogVersion -version $Latest.Version
@@ -13,20 +10,14 @@ function global:au_AfterUpdate {
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt" = @{
-      "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$releases>"
-      "(?i)(\s*32\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL32)>"
-      "(?i)(\s*64\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL64)>"
-      "(?i)(^\s*checksum\s*type\:).*" = "`${1} $($Latest.ChecksumType32)"
-      "(?i)(^\s*checksum(32)?\:).*" = "`${1} $($Latest.Checksum32)"
-      "(?i)(^\s*checksum64\:).*" = "`${1} $($Latest.Checksum64)"
+      "(?i)(64\-Bit software\:\s*)\<.*\>" = "`${1}<$($Latest.URL64)>"
+      "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType64)"
+      "(?i)(^\s*checksum\:).*"            = "`${1} $($Latest.Checksum64)"
     }
-    ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)^(\s*softwareName\s*=\s*)'.*'" = "`${1}'$softwareName'"
-      "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName32)`""
-      "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
-    }
-    ".\tools\chocolateyUninstall.ps1" = @{
-      "(?i)^(\s*softwareName\s*=\s*)'.*'" = "`${1}'$softwareName'"
+    ".\tools\chocolateyinstall.ps1" = @{
+      "(?i)^(\s*url64bit\s*=\s*)'.*'"       = "`${1}'$($Latest.URL64)'"
+      "(?i)^(\s*checksum64\s*=\s*)'.*'"     = "`${1}'$($Latest.Checksum64)'"
+      "(?i)^(\s*checksumType64\s*=\s*)'.*'" = "`${1}'$($Latest.ChecksumType64)'"
     }
   }
 }
@@ -34,24 +25,17 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
-  $re    = 'jubler.*\.exe'
-  $urls   = $download_page.links | Where-Object href -match $re | Select-Object -First 2 -expand href
+  $re  = 'Jubler-.*-x64\.exe$'
+  $url = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href
+  if ($url -notmatch '^https?://') { $url = 'https://github.com' + $url }
 
-  $version  = $urls[0] -split '\/v?' | Select-Object -Last 1 -Skip 1
+  if ($url -match 'Jubler-([\d.]+)-x64\.exe') { $version = $Matches[1] }
 
   @{
-    URL32 = $urls -notmatch "64\.exe" | Select-Object -first 1
-    URL64 = $urls -match "64\.exe" | Select-Object -first 1
-    Version = $version
+    URL64    = $url
+    Version  = $version
     FileType = 'exe'
   }
 }
 
-
-try {
-    update -ChecksumFor none
-} catch {
-    $ignore = "Unable to connect to the remote server"
-    if ($_ -match $ignore) { Write-Host $ignore; 'ignore' } else { throw $_ }
-}
-
+update -ChecksumFor 64


### PR DESCRIPTION
Updates the `jubler` package from 7.0.0/8.0.0 to the current release, **10.0.0**.

The automatic updater had been stuck because `au_GetLatest` scraped `http://www.jubler.org/download.html`, which is no longer maintained. This PR repoints it at the project's GitHub releases page so future versions are picked up automatically.

Changes:
- `update.ps1`: fetch the latest installer from `https://github.com/teras/Jubler/releases/latest` (matching `Jubler-*-x64.exe`); parse the version from the asset name; `-ChecksumFor 64`.
- `chocolateyinstall.ps1`: switch from embedded binaries to download-at-install (`Install-ChocolateyPackage`, `url64bit` + `checksum64`). Jubler 10 ships a single self-contained x64 installer.
- Silent install/uninstall arguments updated for the current Inno Setup based installer (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`).
- Dropped the obsolete `javaruntime`, `smplayer` and `chocolatey-core.extension` dependencies — the installer now bundles its own Java runtime and uses VLC internally.
- Refreshed metadata: `projectUrl`, `licenseUrl`, copyright year, release-notes links, and description/readme (FFMPEG/mplayer references replaced by VLC).
- `VERIFICATION.txt` and `Changelog.md` updated accordingly.